### PR TITLE
Use standard SQL 92 operator for not equal.

### DIFF
--- a/Sources/SQLKit/Query/SQLBinaryOperator.swift
+++ b/Sources/SQLKit/Query/SQLBinaryOperator.swift
@@ -63,7 +63,7 @@ public enum SQLBinaryOperator: SQLExpression {
     public func serialize(to serializer: inout SQLSerializer) {
         switch self {
         case .equal: serializer.write("=")
-        case .notEqual: serializer.write("!=")
+        case .notEqual: serializer.write("<>")
         case .and: serializer.write("AND")
         case .or: serializer.write("OR")
         case .in: serializer.write("IN")


### PR DESCRIPTION
Not every database supports the proprietary operator "!=" as a not equal operator.