### PR TITLE
Allow dialect to suppress IF (NOT) EXISTS

### DIFF
--- a/Sources/SQLKit/Query/SQLCreateTable.swift
+++ b/Sources/SQLKit/Query/SQLCreateTable.swift
@@ -36,7 +36,7 @@ public struct SQLCreateTable: SQLExpression {
             serializer.write("TEMPORARY ")
         }
         serializer.write("TABLE ")
-        if self.ifNotExists {
+        if serializer.dialect.supportsIfExists && self.ifNotExists {
             serializer.write("IF NOT EXISTS ")
         }
         self.table.serialize(to: &serializer)

--- a/Sources/SQLKit/Query/SQLDropTable.swift
+++ b/Sources/SQLKit/Query/SQLDropTable.swift
@@ -18,7 +18,7 @@ public struct SQLDropTable: SQLExpression {
     /// See `SQLExpression`.
     public func serialize(to serializer: inout SQLSerializer) {
         serializer.write("DROP TABLE ")
-        if self.ifExists {
+        if serializer.dialect.supportsIfExists && self.ifExists {
             serializer.write("IF EXISTS ")
         }
         self.table.serialize(to: &serializer)

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -10,10 +10,16 @@ public protocol SQLDialect {
     func literalBoolean(_ value: Bool) -> SQLExpression
 
     var literalDefault: SQLExpression { get }
+
+    var supportsIfExists: Bool { get }
 }
 
 extension SQLDialect {
     public var literalDefault: SQLExpression {
         return SQLRaw("DEFAULT")
+    }
+
+    public var supportsIfExists: Bool {
+        return true
     }
 }

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -46,7 +46,7 @@ final class SQLKitTests: XCTestCase {
         try db.drop(table: "planets").ifExists().run().wait()
         XCTAssertEqual(db.results[0], "DROP TABLE IF EXISTS `planets`")
 
-        db.dialect.supportsIfExistsVar = false
+        db.dialect = GenericDialect(supportsIfExists: false)
         try db.drop(table: "planets").ifExists().run().wait()
         XCTAssertEqual(db.results[1], "DROP TABLE `planets`")
     }

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -39,4 +39,15 @@ final class SQLKitTests: XCTestCase {
         XCTAssertEqual(serializer.sql, "SELECT * FROM planets WHERE name = ?")
         XCTAssert(serializer.binds.first! as! String == "Earth")
     }
+
+    func testIfExists() throws {
+        let db = TestDatabase()
+
+        try db.drop(table: "planets").ifExists().run().wait()
+        XCTAssertEqual(db.results[0], "DROP TABLE IF EXISTS `planets`")
+
+        db.dialect.supportsIfExistsVar = false
+        try db.drop(table: "planets").ifExists().run().wait()
+        XCTAssertEqual(db.results[1], "DROP TABLE `planets`")
+    }
 }

--- a/Tests/SQLKitTests/Utilities.swift
+++ b/Tests/SQLKitTests/Utilities.swift
@@ -3,14 +3,16 @@ import SQLKit
 final class TestDatabase: SQLDatabase {
     let eventLoop: EventLoop
     var results: [String]
+    var dialect: GenericDialect
     
     init() {
         self.eventLoop = EmbeddedEventLoop()
         self.results = []
+        self.dialect = GenericDialect()
     }
     
     func execute(sql query: SQLExpression, _ onRow: @escaping (SQLRow) throws -> ()) -> EventLoopFuture<Void> {
-        var serializer = SQLSerializer(dialect: GenericDialect())
+        var serializer = SQLSerializer(dialect: dialect)
         query.serialize(to: &serializer)
         results.append(serializer.sql)
         return self.eventLoop.makeSucceededFuture(())
@@ -19,6 +21,9 @@ final class TestDatabase: SQLDatabase {
 
 struct GenericDialect: SQLDialect {
     init() { }
+
+    var supportsIfExistsVar: Bool = true
+
     var identifierQuote: SQLExpression {
         return SQLRaw("`")
     }
@@ -40,5 +45,9 @@ struct GenericDialect: SQLDialect {
     
     var autoIncrementClause: SQLExpression {
         return SQLRaw("AUTOINCREMENT")
+    }
+
+    var supportsIfExists: Bool {
+        return supportsIfExistsVar
     }
 }

--- a/Tests/SQLKitTests/Utilities.swift
+++ b/Tests/SQLKitTests/Utilities.swift
@@ -20,9 +20,7 @@ final class TestDatabase: SQLDatabase {
 }
 
 struct GenericDialect: SQLDialect {
-    init() { }
-
-    var supportsIfExistsVar: Bool = true
+    var supportsIfExists: Bool = true
 
     var identifierQuote: SQLExpression {
         return SQLRaw("`")
@@ -45,9 +43,5 @@ struct GenericDialect: SQLDialect {
     
     var autoIncrementClause: SQLExpression {
         return SQLRaw("AUTOINCREMENT")
-    }
-
-    var supportsIfExists: Bool {
-        return supportsIfExistsVar
     }
 }

--- a/Tests/SQLKitTests/XCTestManifests.swift
+++ b/Tests/SQLKitTests/XCTestManifests.swift
@@ -10,6 +10,7 @@ extension SQLKitTests {
         ("testLockingClause_forUpdate", testLockingClause_forUpdate),
         ("testLockingClause_lockInShareMode", testLockingClause_lockInShareMode),
         ("testRawQueryStringInterpolation", testRawQueryStringInterpolation),
+        ("testIfExists", testIfExists),
     ]
 }
 


### PR DESCRIPTION
Fixes #63 and #67 

I am not completely happy with the solution in Utilities.swift to make supportsIfExists customizable for the test. I'd love to hear about a neater solution