### PR TITLE
Implement GROUP BY ... HAVING

### DIFF
--- a/Sources/SQLKit/Builders/SQLPredicateBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLPredicateBuilder.swift
@@ -13,7 +13,7 @@ public protocol SQLPredicateBuilder: class {
 }
 
 extension SQLPredicateBuilder {
-    /// Adds a column to column comparison to this builder's `WHERE` clause.
+    /// Adds a column to column comparison to this builder's `WHERE` clause by `AND`ing.
     ///
     ///     builder.where("firstName", .equal, column: "lastName")
     ///
@@ -22,15 +22,14 @@ extension SQLPredicateBuilder {
     ///     SELECT * FROM users WHERE firstName = lastName
     ///
     /// - parameters:
-    ///     - lhs: Left-hand column name.
+    ///     - lhs: Left-hand side column name.
     ///     - op: Binary operator to use for comparison.
-    ///     - rhs: Right-hand column name.
-    /// - returns: Self for chaining.
+    ///     - rhs: Right-hand side column name.
     public func `where`(_ lhs: String, _ op: SQLBinaryOperator, column rhs: String) -> Self {
         return self.where(SQLIdentifier(lhs), op, SQLIdentifier(rhs))
     }
-    
-    /// Adds a column comparison to this builder's `WHERE` clause.
+
+    /// Adds a column to encodable comparison to this builder's `WHERE` clause by `AND`ing.
     ///
     ///     builder.where("name", .equal, "Earth")
     ///
@@ -39,44 +38,59 @@ extension SQLPredicateBuilder {
     ///     SELECT * FROM planets WHERE name = ? // Earth
     ///
     /// - parameters:
-    ///     - lhs: Column name.
+    ///     - lhs: Left-hand side column name.
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Encodable value.
     /// - returns: Self for chaining.
     public func `where`(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: Encodable) -> Self {
         return self.where(SQLIdentifier(lhs), op, SQLBind(rhs))
     }
-    
-    /// Adds an expression to the `WHERE` clause.
+
+    /// Adds a column to expression comparison to the `WHERE` clause by `AND`ing.
     ///
-    ///     builder.where(.column("name"), .equal, .value("Earth"))
+    ///     builder.where("name", .equal, .value("Earth"))
     ///
+    /// - parameters:
+    ///     - lhs: Left-hand side column name.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side expression.
     public func `where`(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
         return self.where(SQLIdentifier(lhs), op, rhs)
     }
-    
-    /// Adds an expression to the `WHERE` clause.
+
+    /// Adds a expression to expression comparison to the `WHERE` clause by `AND`ing.
     ///
-    ///     builder.where(.column("name"), .equal, .value("Earth"))
+    ///     builder.where("name", .equal, .value("Earth"))
     ///
+    /// - parameters:
+    ///     - lhs: Left-hand side expression.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side expression.
+    /// - returns: Self for chaining.
     public func `where`(_ lhs: SQLExpression, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
         return self.where(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
-    
-    /// Adds an expression to the `WHERE` clause.
+
+    /// Adds a expression to expression comparison, with an arbitrary
+    /// expression as operator, to the `WHERE` clause by `AND`ing.
     ///
-    ///     builder.where(.column("name"), .equal, .value("Earth"))
+    ///     builder.where("name", .equal, .value("Earth"))
     ///
+    /// - parameters:
+    ///     - lhs: Left-hand side expression.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side expression.
+    /// - returns: Self for chaining.
     public func `where`(_ lhs: SQLExpression, _ op: SQLExpression, _ rhs: SQLExpression) -> Self {
         return self.where(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
 
-    /// Adds an expression to the `WHERE` clause.
+    /// Adds an expression to the `WHERE` clause by `AND`ing.
     ///
     ///     builder.where(.binary("name", .notEqual, .literal(.null)))
     ///
     /// - parameters:
-    ///     - expression: Expression to be added via `AND` to the predicate.
+    ///     - expression: Expression to be added to the predicate.
     public func `where`(_ expression: SQLExpression) -> Self {
         if let existing = self.predicate {
             self.predicate = SQLBinaryExpression(
@@ -90,36 +104,51 @@ extension SQLPredicateBuilder {
         return self
     }
 
-    /// Adds an expression to the `WHERE` clause.
+    /// Adds a column to expression comparison to the `WHERE` clause by `OR`ing.
     ///
-    ///     builder.orWhere(.column("name"), .equal, .value("Earth"))
+    ///     builder.orWhere("name", .equal, .value("Earth"))
     ///
+    /// - parameters:
+    ///     - lhs: Left-hand side column name.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side expression.
     public func orWhere(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
         return self.orWhere(SQLIdentifier(lhs), op, rhs)
     }
-    
-    /// Adds an expression to the `WHERE` clause.
+
+    /// Adds a expression to expression comparison to the `WHERE` clause by `OR`ing.
     ///
-    ///     builder.orWhere(.column("name"), .equal, .value("Earth"))
+    ///     builder.orWhere("name", .equal, .value("Earth"))
     ///
+    /// - parameters:
+    ///     - lhs: Left-hand side expression.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side expression.
+    /// - returns: Self for chaining.
     public func orWhere(_ lhs: SQLExpression, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
         return self.orWhere(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
-    
-    /// Adds an expression to the `WHERE` clause.
+
+    /// Adds a expression to expression comparison, with an arbitrary
+    /// expression as operator, to the `WHERE` clause by `OR`ing.
     ///
-    ///     builder.orWhere(.column("name"), .equal, .value("Earth"))
+    ///     builder.orWhere("name", .equal, .value("Earth"))
     ///
+    /// - parameters:
+    ///     - lhs: Left-hand side expression.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side expression.
+    /// - returns: Self for chaining.
     public func orWhere(_ lhs: SQLExpression, _ op: SQLExpression, _ rhs: SQLExpression) -> Self {
         return self.orWhere(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
-    
-    /// Adds an expression to the `WHERE` clause.
+
+    /// Adds an expression to the `WHERE` clause by `OR`ing.
     ///
     ///     builder.orWhere(.binary("name", .notEqual, .literal(.null)))
     ///
     /// - parameters:
-    ///     - expression: Expression to be added via `AND` to the predicate.
+    ///     - expression: Expression to be added to the predicate.
     public func orWhere(_ expression: SQLExpression) -> Self {
         if let existing = self.predicate {
             self.predicate = SQLBinaryExpression(

--- a/Sources/SQLKit/Builders/SQLPredicateBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLPredicateBuilder.swift
@@ -58,7 +58,7 @@ extension SQLPredicateBuilder {
         return self.where(SQLIdentifier(lhs), op, rhs)
     }
 
-    /// Adds a expression to expression comparison to the `WHERE` clause by `AND`ing.
+    /// Adds an expression to expression comparison to the `WHERE` clause by `AND`ing.
     ///
     ///     builder.where("name", .equal, .value("Earth"))
     ///
@@ -71,7 +71,7 @@ extension SQLPredicateBuilder {
         return self.where(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
 
-    /// Adds a expression to expression comparison, with an arbitrary
+    /// Adds an expression to expression comparison, with an arbitrary
     /// expression as operator, to the `WHERE` clause by `AND`ing.
     ///
     ///     builder.where("name", .equal, .value("Earth"))
@@ -116,7 +116,7 @@ extension SQLPredicateBuilder {
         return self.orWhere(SQLIdentifier(lhs), op, rhs)
     }
 
-    /// Adds a expression to expression comparison to the `WHERE` clause by `OR`ing.
+    /// Adds an expression to expression comparison to the `WHERE` clause by `OR`ing.
     ///
     ///     builder.orWhere("name", .equal, .value("Earth"))
     ///
@@ -129,7 +129,7 @@ extension SQLPredicateBuilder {
         return self.orWhere(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
 
-    /// Adds a expression to expression comparison, with an arbitrary
+    /// Adds an expression to expression comparison, with an arbitrary
     /// expression as operator, to the `WHERE` clause by `OR`ing.
     ///
     ///     builder.orWhere("name", .equal, .value("Earth"))

--- a/Sources/SQLKit/Builders/SQLSelectBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLSelectBuilder.swift
@@ -163,6 +163,66 @@ public final class SQLSelectBuilder: SQLQueryFetcher, SQLQueryBuilder, SQLPredic
     
 }
 
+extension SQLSelectBuilder {
+    public func having(_ lhs: String, _ op: SQLBinaryOperator, column rhs: String) -> Self {
+        return self.having(SQLIdentifier(lhs), op, SQLIdentifier(rhs))
+    }
+
+    public func having(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: Encodable) -> Self {
+        return self.having(SQLIdentifier(lhs), op, SQLBind(rhs))
+    }
+
+    public func having(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
+        return self.having(SQLIdentifier(lhs), op, rhs)
+    }
+
+    public func having(_ lhs: SQLExpression, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
+        return self.having(SQLBinaryExpression(left: lhs, op: op, right: rhs))
+    }
+
+    public func having(_ lhs: SQLExpression, _ op: SQLExpression, _ rhs: SQLExpression) -> Self {
+        return self.having(SQLBinaryExpression(left: lhs, op: op, right: rhs))
+    }
+
+    public func having(_ expression: SQLExpression) -> Self {
+        if let existing = self.select.having {
+            self.select.having = SQLBinaryExpression(
+                left: existing,
+                op: SQLBinaryOperator.and,
+                right: expression
+            )
+        } else {
+            self.select.having = expression
+        }
+        return self
+    }
+
+    public func orHaving(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
+        return self.orHaving(SQLIdentifier(lhs), op, rhs)
+    }
+
+    public func orHaving(_ lhs: SQLExpression, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
+        return self.orHaving(SQLBinaryExpression(left: lhs, op: op, right: rhs))
+    }
+
+    public func orHaving(_ lhs: SQLExpression, _ op: SQLExpression, _ rhs: SQLExpression) -> Self {
+        return self.orHaving(SQLBinaryExpression(left: lhs, op: op, right: rhs))
+    }
+
+    public func orHaving(_ expression: SQLExpression) -> Self {
+        if let existing = self.select.having {
+            self.select.having = SQLBinaryExpression(
+                left: existing,
+                op: SQLBinaryOperator.or,
+                right: expression
+            )
+        } else {
+            self.select.having = expression
+        }
+        return self
+    }
+}
+
 // MARK: Connection
 
 extension SQLDatabase {

--- a/Sources/SQLKit/Builders/SQLSelectBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLSelectBuilder.swift
@@ -210,7 +210,7 @@ extension SQLSelectBuilder {
         return self.having(SQLIdentifier(lhs), op, rhs)
     }
 
-    /// Adds a expression to expression comparison to the `HAVING` clause by `AND`ing.
+    /// Adds an expression to expression comparison to the `HAVING` clause by `AND`ing.
     ///
     ///     builder.having("name", .equal, .value("Earth"))
     ///
@@ -223,7 +223,7 @@ extension SQLSelectBuilder {
         return self.having(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
 
-    /// Adds a expression to expression comparison, with an arbitrary
+    /// Adds an expression to expression comparison, with an arbitrary
     /// expression as operator, to the `HAVING` clause by `AND`ing.
     ///
     ///     builder.having("name", .equal, .value("Earth"))
@@ -269,7 +269,7 @@ extension SQLSelectBuilder {
         return self.orHaving(SQLIdentifier(lhs), op, rhs)
     }
 
-    /// Adds a expression to expression comparison to the `HAVING` clause by `OR`ing.
+    /// Adds an expression to expression comparison to the `HAVING` clause by `OR`ing.
     ///
     ///     builder.orHaving("name", .equal, .value("Earth"))
     ///
@@ -282,7 +282,7 @@ extension SQLSelectBuilder {
         return self.orHaving(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
 
-    /// Adds a expression to expression comparison, with an arbitrary
+    /// Adds an expression to expression comparison, with an arbitrary
     /// expression as operator, to the `HAVING` clause by `OR`ing.
     ///
     ///     builder.orHaving("name", .equal, .value("Earth"))

--- a/Sources/SQLKit/Builders/SQLSelectBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLSelectBuilder.swift
@@ -160,30 +160,89 @@ public final class SQLSelectBuilder: SQLQueryFetcher, SQLQueryBuilder, SQLPredic
         self.select.offset = n
         return self
     }
-    
 }
 
 extension SQLSelectBuilder {
+    /// Adds a column to column comparison to this builder's `HAVING` clause by `AND`ing.
+    ///
+    ///     builder.having("firstName", .equal, column: "lastName")
+    ///
+    /// This method compares two _columns_.
+    ///
+    ///     SELECT * FROM users HAVING firstName = lastName
+    ///
+    /// - parameters:
+    ///     - lhs: Left-hand side column name.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side column name.
+    /// - returns: Self for chaining.
     public func having(_ lhs: String, _ op: SQLBinaryOperator, column rhs: String) -> Self {
         return self.having(SQLIdentifier(lhs), op, SQLIdentifier(rhs))
     }
 
+    /// Adds a column to encodable comparison to this builder's `HAVING` clause by `AND`ing.
+    ///
+    ///     builder.having("name", .equal, "Earth")
+    ///
+    /// The encodable value supplied will be bound to the query as a parameter.
+    ///
+    ///     SELECT * FROM planets HAVING name = ? // Earth
+    ///
+    /// - parameters:
+    ///     - lhs: Left-hand side column name.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Encodable value.
+    /// - returns: Self for chaining.
     public func having(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: Encodable) -> Self {
         return self.having(SQLIdentifier(lhs), op, SQLBind(rhs))
     }
 
+    /// Adds a column to expression comparison to the `HAVING` clause by `AND`ing.
+    ///
+    ///     builder.having("name", .equal, .value("Earth"))
+    ///
+    /// - parameters:
+    ///     - lhs: Left-hand side column name.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side expression.
+    /// - returns: Self for chaining.
     public func having(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
         return self.having(SQLIdentifier(lhs), op, rhs)
     }
 
+    /// Adds a expression to expression comparison to the `HAVING` clause by `AND`ing.
+    ///
+    ///     builder.having("name", .equal, .value("Earth"))
+    ///
+    /// - parameters:
+    ///     - lhs: Left-hand side expression.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side expression.
+    /// - returns: Self for chaining.
     public func having(_ lhs: SQLExpression, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
         return self.having(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
 
+    /// Adds a expression to expression comparison, with an arbitrary
+    /// expression as operator, to the `HAVING` clause by `AND`ing.
+    ///
+    ///     builder.having("name", .equal, .value("Earth"))
+    ///
+    /// - parameters:
+    ///     - lhs: Left-hand side expression.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side expression.
+    /// - returns: Self for chaining.
     public func having(_ lhs: SQLExpression, _ op: SQLExpression, _ rhs: SQLExpression) -> Self {
         return self.having(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
 
+    /// Adds an expression to the `HAVING` clause by `AND`ing.
+    ///
+    ///     builder.having(.binary("name", .notEqual, .literal(.null)))
+    ///
+    /// - parameters:
+    ///     - expression: Expression to be added to the predicate.
     public func having(_ expression: SQLExpression) -> Self {
         if let existing = self.select.having {
             self.select.having = SQLBinaryExpression(
@@ -197,18 +256,52 @@ extension SQLSelectBuilder {
         return self
     }
 
+    /// Adds a column to expression comparison to the `HAVING` clause by `OR`ing.
+    ///
+    ///     builder.orHaving("name", .equal, .value("Earth"))
+    ///
+    /// - parameters:
+    ///     - lhs: Left-hand side column name.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side expression.
+    /// - returns: Self for chaining.
     public func orHaving(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
         return self.orHaving(SQLIdentifier(lhs), op, rhs)
     }
 
+    /// Adds a expression to expression comparison to the `HAVING` clause by `OR`ing.
+    ///
+    ///     builder.orHaving("name", .equal, .value("Earth"))
+    ///
+    /// - parameters:
+    ///     - lhs: Left-hand side expression.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side expression.
+    /// - returns: Self for chaining.
     public func orHaving(_ lhs: SQLExpression, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
         return self.orHaving(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
 
+    /// Adds a expression to expression comparison, with an arbitrary
+    /// expression as operator, to the `HAVING` clause by `OR`ing.
+    ///
+    ///     builder.orHaving("name", .equal, .value("Earth"))
+    ///
+    /// - parameters:
+    ///     - lhs: Left-hand side expression.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side expression.
+    /// - returns: Self for chaining.
     public func orHaving(_ lhs: SQLExpression, _ op: SQLExpression, _ rhs: SQLExpression) -> Self {
         return self.orHaving(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
 
+    /// Adds an expression to the `HAVING` clause by `OR`ing.
+    ///
+    ///     builder.orHaving(.binary("name", .notEqual, .literal(.null)))
+    ///
+    /// - parameters:
+    ///     - expression: Expression to be added to the predicate.
     public func orHaving(_ expression: SQLExpression) -> Self {
         if let existing = self.select.having {
             self.select.having = SQLBinaryExpression(

--- a/Sources/SQLKit/Query/SQLSelect.swift
+++ b/Sources/SQLKit/Query/SQLSelect.swift
@@ -13,7 +13,9 @@ public struct SQLSelect: SQLExpression {
     
     /// Zero or more `GROUP BY` clauses.
     public var groupBy: [SQLExpression]
-    
+
+    public var having: SQLExpression?
+
     /// Zero or more `ORDER BY` clauses.
     public var orderBy: [SQLExpression]
     
@@ -40,6 +42,7 @@ public struct SQLSelect: SQLExpression {
         self.limit = nil
         self.offset = nil
         self.groupBy = []
+        self.having = nil
         self.orderBy = []
     }
     
@@ -62,6 +65,10 @@ public struct SQLSelect: SQLExpression {
         if !self.groupBy.isEmpty {
             serializer.write(" GROUP BY ")
             SQLList(self.groupBy).serialize(to: &serializer)
+        }
+        if let having = self.having {
+            serializer.write(" HAVING ")
+            having.serialize(to: &serializer)
         }
         if !self.orderBy.isEmpty {
             serializer.write(" ORDER BY ")

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -39,4 +39,14 @@ final class SQLKitTests: XCTestCase {
         XCTAssertEqual(serializer.sql, "SELECT * FROM planets WHERE name = ?")
         XCTAssert(serializer.binds.first! as! String == "Earth")
     }
+
+    func testGroupByHaving() throws {
+        let db = TestDatabase()
+        try db.select().column("*")
+            .from("planets")
+            .groupBy("color")
+            .having("color", .equal, "blue")
+            .run().wait()
+        XCTAssertEqual(db.results[0], "SELECT * FROM `planets` GROUP BY `color` HAVING `color` = ?")
+    }
 }

--- a/Tests/SQLKitTests/XCTestManifests.swift
+++ b/Tests/SQLKitTests/XCTestManifests.swift
@@ -10,6 +10,7 @@ extension SQLKitTests {
         ("testLockingClause_forUpdate", testLockingClause_forUpdate),
         ("testLockingClause_lockInShareMode", testLockingClause_lockInShareMode),
         ("testRawQueryStringInterpolation", testRawQueryStringInterpolation),
+        ("testGroupByHaving", testGroupByHaving),
     ]
 }
 


### PR DESCRIPTION
I started working on fixing #58, but ran into the issue that reusing code by inheriting `SQLPredicateBuilder` is really possible, for two reasons:

1. `SQLPredicateBuilder` defines functions `where` and `orWhere`, while we want them to be called `having` and `orHaving`, and Swift generics don't seem to be able to rename functions at will (it's not C++ after all :wink:)
2. More importantly, `SQLSelectBuilder` already inherits `SQLPredicateBuilder`, so that really makes it impossible.

To quickly recap the issue, we basically want this:

```swift
db.select().column("*")
    .from("planets")
    .where(...)
    .groupBy("color")
    .having(...)
```

to translate to ```SELECT * FROM `planets` WHERE ... GROUP BY `color` HAVING ...```

I can see 4 possible solutions for this:

1. The simplest: Just copying over the `where`/`orWhere` functions from `SQLPredicateBuilder`, renaming them to `having`/`orHaving` and calling it a day _(as I have done in this draft PR, for now)_
2. Duplicating `SQLPredicateBuilder.swift`, calling it `SQLHavingBuilder.swift` (or something), changing the necessary references and again calling it a day (not much unlike option 1)
3. Making `groupBy` return a `SQLGroupByBuilder` instead of `Self`, which then inherits `SQLPredicateBuilder` itself too, which results in this syntax:
    ```swift
    db.select().column("*")
        .from("planets")
        .where(...)
        .groupBy("color")
        .where(...)
    ```
    I really don't like it...
4. Using `dynamicCallable`s, new in Swift 5! I have never used them, and I only know them from a few blog posts, but looking [this one](https://www.alwaysrightinstitute.com/swift-dynamic-callable/) I have a good feeling it's possible to solve our problem.

   *But...* Doing this will make the code base much more complex, perhaps unnecessarily so. I imagine there are plenty of footguns that come for free with this solution, and perhaps just taking the easy way out (option 1) is the best solution.

`SELECT` is, as far as I know, the only statement that even supports `GROUP BY`, and by extension `HAVING`, so should we be worried so much? If you agree, I'll just add documentation to the PR and we'll be good.