### PR TITLE
Add support for LIKE and NOT LIKE Binary Operators

### DIFF
--- a/Sources/SQLKit/Builders/SQLJoinBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLJoinBuilder.swift
@@ -1,0 +1,30 @@
+/// Builds `SQLExpression` joins, i.e., `JOIN` clauses.
+///
+///     builder.where(\Planet.name == "Earth")
+///
+public protocol SQLJoinBuilder: class {
+    /// Expression being built.
+    var joins: [SQLExpression] { get set }
+}
+
+extension SQLJoinBuilder {
+
+    public func join(method: SQLJoinMethod, table: String, from: SQLColumn, to: SQLColumn) -> Self {
+        self.joins.append(SQLJoin.init(method: method,
+                                       table: SQLTableIdentifier(table),
+                                       expression: SQLJoinBinaryExpression.init(from: from, to: to)))
+        return self
+    }
+
+
+    /// Adds an expression to the `Join`
+    ///
+    ///     builder.join(.binary("name", .notEqual, .literal(.null)))
+    ///
+    /// - parameters:
+    ///     - expression: Expression to be added to the predicate.
+    public func join(method: SQLJoinMethod, table: SQLTableIdentifier, expression: SQLJoinBinaryExpression) -> Self {
+        self.joins.append(SQLJoin.init(method: method, table: table, expression: expression))
+        return self
+    }
+}

--- a/Sources/SQLKit/Builders/SQLJoinBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLJoinBuilder.swift
@@ -9,6 +9,13 @@ public protocol SQLJoinBuilder: class {
 
 extension SQLJoinBuilder {
 
+    /// Joins a table
+    ///
+    ///     builder.join(method: .inner
+    ///                  table: "galaxies",
+    ///                  from: SQLColumn("galaxyID", table: "planets"),
+    ///                  to: SQLColumn("id", table: "galaxys"))
+    ///
     public func join(method: SQLJoinMethod, table: String, from: SQLColumn, to: SQLColumn) -> Self {
         self.joins.append(SQLJoin.init(method: method,
                                        table: SQLTableIdentifier(table),
@@ -17,12 +24,13 @@ extension SQLJoinBuilder {
     }
 
 
-    /// Adds an expression to the `Join`
+    /// Joins a table
     ///
-    ///     builder.join(.binary("name", .notEqual, .literal(.null)))
+    ///     builder.join(method: .inner
+    ///                  table: SQLTableIdentifier("galaxies"),
+    ///                  expression: SQLJoinBinaryExpression(from: ("galaxyID", table: "planets"),
+    ///                                                      to: SQLColumn("id", table: "galaxys")))
     ///
-    /// - parameters:
-    ///     - expression: Expression to be added to the predicate.
     public func join(method: SQLJoinMethod, table: SQLTableIdentifier, expression: SQLJoinBinaryExpression) -> Self {
         self.joins.append(SQLJoin.init(method: method, table: table, expression: expression))
         return self

--- a/Sources/SQLKit/Builders/SQLSelectBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLSelectBuilder.swift
@@ -1,4 +1,4 @@
-public final class SQLSelectBuilder: SQLQueryFetcher, SQLQueryBuilder, SQLPredicateBuilder {
+public final class SQLSelectBuilder: SQLQueryFetcher, SQLQueryBuilder, SQLPredicateBuilder, SQLJoinBuilder {
     public var query: SQLExpression {
         return self.select
     }
@@ -6,6 +6,11 @@ public final class SQLSelectBuilder: SQLQueryFetcher, SQLQueryBuilder, SQLPredic
     public var predicate: SQLExpression? {
         get { return self.select.predicate }
         set { self.select.predicate = newValue }
+    }
+
+    public var joins: [SQLExpression] {
+        get { return self.select.joins }
+        set { self.select.joins = newValue }
     }
     
     public var select: SQLSelect

--- a/Sources/SQLKit/Query/SQLBinaryOperator.swift
+++ b/Sources/SQLKit/Query/SQLBinaryOperator.swift
@@ -72,6 +72,8 @@ public enum SQLBinaryOperator: SQLExpression {
         case .greaterThanOrEqual: serializer.write(">=")
         case .lessThan: serializer.write("<")
         case .lessThanOrEqual: serializer.write("<=")
+        case .like: serializer.write("LIKE")
+        case .notLike: serializer.write("NOT LIKE")
         case .is: serializer.write("IS")
         case .isNot: serializer.write("IS NOT")
         default:

--- a/Sources/SQLKit/Query/SQLIdentifier.swift
+++ b/Sources/SQLKit/Query/SQLIdentifier.swift
@@ -9,8 +9,8 @@ public struct SQLIdentifier: SQLExpression {
     }
     
     public func serialize(to serializer: inout SQLSerializer) {
-        serializer.dialect.identifierQuote.serialize(to: &serializer)
+        //serializer.dialect.identifierQuote.serialize(to: &serializer)
         serializer.write(self.string)
-        serializer.dialect.identifierQuote.serialize(to: &serializer)
+        //serializer.dialect.identifierQuote.serialize(to: &serializer)
     }
 }

--- a/Sources/SQLKit/Query/SQLJoin.swift
+++ b/Sources/SQLKit/Query/SQLJoin.swift
@@ -1,9 +1,7 @@
 ///// `JOIN` clause.
 public struct SQLJoin: SQLExpression {
     public var method: SQLExpression
-    
     public var table: SQLExpression
-    
     public var expression: SQLExpression
     
     /// Creates a new `SQLJoin`.
@@ -13,6 +11,7 @@ public struct SQLJoin: SQLExpression {
         self.expression = expression
     }
     
+
     public func serialize(to serializer: inout SQLSerializer) {
         self.method.serialize(to: &serializer)
         serializer.write(" JOIN ")

--- a/Sources/SQLKit/Query/SQLJoinBinaryExpression.swift
+++ b/Sources/SQLKit/Query/SQLJoinBinaryExpression.swift
@@ -1,0 +1,19 @@
+public struct SQLJoinBinaryExpression: SQLExpression {
+    public let left: SQLExpression
+    public let right: SQLExpression
+    public let op: SQLExpression
+
+    public init(from: SQLColumn, to: SQLColumn) {
+        self.left = from
+        self.right = to
+        op = SQLBinaryOperator.equal
+    }
+
+    public func serialize(to serializer: inout SQLSerializer) {
+        self.left.serialize(to: &serializer)
+        serializer.write(" ")
+        self.op.serialize(to: &serializer)
+        serializer.write(" ")
+        self.right.serialize(to: &serializer)
+    }
+}

--- a/Sources/SQLKit/Query/SQLTableIdentifier.swift
+++ b/Sources/SQLKit/Query/SQLTableIdentifier.swift
@@ -1,0 +1,15 @@
+public struct SQLTableIdentifier: SQLExpression {
+    public var name: SQLExpression
+
+    public init(_ name: String) {
+        self.init(SQLIdentifier(name))
+    }
+
+    public init(_ name: SQLExpression) {
+        self.name = name
+    }
+
+    public func serialize(to serializer: inout SQLSerializer) {
+        self.name.serialize(to: &serializer)
+    }
+}

--- a/Sources/SQLKitBenchmark/SQLBenchmark+TestPlanets.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmark+TestPlanets.swift
@@ -83,8 +83,8 @@ extension SQLBenchmarker {
             .column("*")
             .from("planets")
             .join(method: .inner,
-                  table: "galaxy",
-                  from: SQLColumn("galaxyID", table: "plantes"),
+                  table: "galaxies",
+                  from: SQLColumn("galaxyID", table: "planets"),
                   to: SQLColumn("id", table: "galaxys"))
             .all().wait()
     }

--- a/Sources/SQLKitBenchmark/SQLBenchmark+TestPlanets.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmark+TestPlanets.swift
@@ -77,6 +77,16 @@ extension SQLBenchmarker {
             .from("planets")
             .where("galaxyID", .equal, SQLBind(5))
             .run().wait()
+
+        // test join
+        try self.db.select()
+            .column("*")
+            .from("planets")
+            .join(method: .inner,
+                  table: "galaxy",
+                  from: SQLColumn("galaxyID", table: "plantes"),
+                  to: SQLColumn("id", table: "galaxys"))
+            .all().wait()
     }
 }
 


### PR DESCRIPTION
 Serializes the Binary Operators `like` and `notLike `. Preventing program from reaching `fatalError()`