### PR TITLE
Add enum type

### DIFF
--- a/Sources/SQLKit/Query/SQLDataType.swift
+++ b/Sources/SQLKit/Query/SQLDataType.swift
@@ -6,6 +6,7 @@ public enum SQLDataType: SQLExpression {
     case text
     case real
     case blob
+    case `enum`(SQLEnumType)
     case custom(SQLExpression)
     
     public func serialize(to serializer: inout SQLSerializer) {
@@ -23,9 +24,17 @@ public enum SQLDataType: SQLExpression {
             sql = SQLRaw("REAL")
         case .blob:
             sql = SQLRaw("BLOB")
+        case .enum(let sqlEnum):
+            sql = sqlEnum
         case .custom(let expression):
             sql = expression
         }
         sql.serialize(to: &serializer)
+    }
+}
+
+extension SQLDataType {
+    public static func `enum`(name: String, values: String...) -> SQLDataType {
+        return .enum(.init(name: name, values: values))
     }
 }

--- a/Sources/SQLKit/Query/SQLEnumType.swift
+++ b/Sources/SQLKit/Query/SQLEnumType.swift
@@ -16,7 +16,7 @@ public struct SQLEnumType: SQLExpression {
 
     /// Creates a new `SQLEnumType`.
     public init(name: String, values: [String]) {
-        self.init(name: SQLRaw(name), values: values.map { SQLRaw($0) })
+        self.init(name: SQLRaw(name), values: values.map { SQLLiteral.string($0) })
     }
 
     public func serialize(to serializer: inout SQLSerializer) {

--- a/Sources/SQLKit/Query/SQLEnumType.swift
+++ b/Sources/SQLKit/Query/SQLEnumType.swift
@@ -1,0 +1,39 @@
+/// `ENUM` type.
+///
+/// See `SQLDataType`.
+public struct SQLEnumType: SQLExpression {
+    /// The name of the enum type.
+    public var name: SQLExpression
+
+    /// The possible values of the enum type.
+    public var values: [SQLExpression]
+
+    /// Creates a new `SQLEnumType`.
+    public init(name: SQLExpression, values: [SQLExpression]) {
+        self.name = name
+        self.values = values
+    }
+
+    /// Creates a new `SQLEnumType`.
+    public init(name: String, values: [String]) {
+        self.init(name: SQLRaw(name), values: values.map { SQLRaw($0) })
+    }
+
+    public func serialize(to serializer: inout SQLSerializer) {
+        switch serializer.dialect.enumSyntax {
+        case .inline(literal: let literal):
+            literal.serialize(to: &serializer)
+            SQLGroupExpression(values).serialize(to: &serializer)
+
+        case .typeName:
+            name.serialize(to: &serializer)
+
+        case .unsupported:
+            // NOTE: Consider using a CHECK constraint
+            //      with a TEXT type to verify that the
+            //      text value for a column is in a list
+            //      of possible options.
+            fatalError("ENUM types are unsupported by the current dialect.")
+        }
+    }
+}

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -7,6 +7,21 @@ public protocol SQLDialect {
     func literalBoolean(_ value: Bool) -> SQLExpression
     var literalDefault: SQLExpression { get }
     var supportsIfExists: Bool { get }
+
+    var enumSyntax: SQLEnumSyntax { get }
+}
+
+public enum SQLEnumSyntax {
+    /// for ex. MySQL, which uses the ENUM literal followed by the options
+    case inline(literal: SQLExpression)
+
+    /// for ex. PostgreSQL, which uses the name of type that must have been
+    /// previously created.
+    case typeName
+
+    /// for ex. SQL Server, which does not have an enum syntax.
+    /// - note: you can likely simulate an enum with a CHECK constraint.
+    case unsupported
 }
 
 extension SQLDialect {

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -60,6 +60,25 @@ final class SQLKitTests: XCTestCase {
         try db.drop(table: "planets").ifExists().run().wait()
         XCTAssertEqual(db.results[1], "DROP TABLE `planets`")
     }
+
+    func testEnumType() throws {
+        let db = TestDatabase()
+
+        // ensure test is using inline enum syntax
+        db._dialect.enumSyntax = .inline(literal: SQLRaw("ENUM"))
+
+        try db.create(table: "planets")
+            .column("size", type: .enum(name: "size", values: "small", "medium", "large"))
+            .run().wait()
+        XCTAssertEqual(db.results[0], "CREATE TABLE `planets`(`size` ENUM('small', 'medium', 'large'))")
+
+        db._dialect.enumSyntax = .typeName
+
+        try db.create(table: "planets")
+            .column("size", type: .enum(name: "SIZE", values: "small", "medium", "large"))
+            .run().wait()
+        XCTAssertEqual(db.results[1], "CREATE TABLE `planets`(`size` SIZE)")
+    }
 }
 
 // MARK: Table Creation

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -72,6 +72,7 @@ final class SQLKitTests: XCTestCase {
             .run().wait()
         XCTAssertEqual(db.results[0], "CREATE TABLE `planets`(`size` ENUM('small', 'medium', 'large'))")
 
+        // switch to type name enum syntax
         db._dialect.enumSyntax = .typeName
 
         try db.create(table: "planets")

--- a/Tests/SQLKitTests/Utilities.swift
+++ b/Tests/SQLKitTests/Utilities.swift
@@ -50,6 +50,8 @@ struct GenericDialect: SQLDialect {
         case false: return SQLRaw("false")
         }
     }
+
+    var enumSyntax: SQLEnumSyntax = .inline(literal: SQLRaw("ENUM"))
     
     var autoIncrementClause: SQLExpression {
         return SQLRaw("AUTOINCREMENT")


### PR DESCRIPTION
Closes https://github.com/vapor/sql-kit/issues/80

**NOTE** this updates `SQLDialect` and therefore is a breaking change. I will submit PRs to MySQL-Kit, PostgreSQL-Kit, and SQLite-Kit if the changes in this PR are approved.

I added this with a dialect option because there are definitely three categories of SQL implementations of enumerations.
1. inline support; examples include [MySQL](https://dev.mysql.com/doc/refman/8.0/en/enum.html), [NuoDB](http://doc.nuodb.com/Latest/Content/SQL-Enumerated-Types.htm), and [MariaDB](https://mariadb.com/kb/en/library/enum/)
2. type-level support; only example I know of is [Postgres](https://www.postgresql.org/docs/9.1/datatype-enum.html), but IMO it deserves "first class support"
3. unsupported; examples include [SQL Server](https://social.msdn.microsoft.com/Forums/sqlserver/en-US/c7abe3c1-cd48-4ddf-9ce2-b28d0ffb25f6/enum-in-sql-server?forum=transactsql) and SQLite.

Technically SQL Server and possibly others could just quietly use `CHECK` constraints to implement a pseudo enum-type, but IMO this is better left to the user rather than sneakily implemented via a different feature to which the user also has access.

The changes in this PR facilitate direct usage of the `enum` `SQLDatatype` as
```swift
database.create(table: "tmp")
  .column("example", type: .enum(name: "ENUM_TYPE", values: "one", "two", "three"))
  .run()
```

However, the better interface will come from an extension on `SQLDataType` implemented in more specialized libraries.
For example, in PostgresKit
```swift
extension SQLDataType {
  public static func `enum`(_ name: String) -> SQLDataType {
    return .enum(.init(name: name, values: []))
  }
}
```
would facilitate using an enum type and only specifying the name (the possible values are created elsewhere under a postgres type).

Similarly, in MySQLKit
```swift
extension SQLDataType {
  public static func `enum`(_ values: String...) -> SQLDataType {
    return .enum(.init(name: "", values: values))
  }
}
```
would facilitate using an enum without specifying its name (because MySQL enums are anonymous).

Do we need to worry about name collision if MySQLKit and PostgresKit are both imported and provide the above extensions? Not sure if that's a use-case that needs to be supported, but the signatures could be tweaked to not collide without loosing too much brevity.

[EDIT]
A bit of an afterthought (not included in current PR, but easily added):
```swift
extension SQLDataType {
  public static func `enum`<T: CaseIterable>(name: String, _ valuesFrom: T.Type) -> SQLDataType where T: RawRepresentable, T.RawValue == String {
    return .enum(.init(name: name, values: T.allCases.map { $0.rawValue }))
  }
}
```