### PR TITLE
Enum (take 2)

### DIFF
--- a/Sources/SQLKit/Query/SQLDataType.swift
+++ b/Sources/SQLKit/Query/SQLDataType.swift
@@ -6,7 +6,6 @@ public enum SQLDataType: SQLExpression {
     case text
     case real
     case blob
-    case `enum`(SQLEnumType)
     case custom(SQLExpression)
     
     public func serialize(to serializer: inout SQLSerializer) {
@@ -24,17 +23,9 @@ public enum SQLDataType: SQLExpression {
             sql = SQLRaw("REAL")
         case .blob:
             sql = SQLRaw("BLOB")
-        case .enum(let sqlEnum):
-            sql = sqlEnum
         case .custom(let expression):
             sql = expression
         }
         sql.serialize(to: &serializer)
-    }
-}
-
-extension SQLDataType {
-    public static func `enum`(name: String, values: String...) -> SQLDataType {
-        return .enum(.init(name: name, values: values))
     }
 }

--- a/Sources/SQLKit/Query/SQLDataType.swift
+++ b/Sources/SQLKit/Query/SQLDataType.swift
@@ -6,6 +6,7 @@ public enum SQLDataType: SQLExpression {
     case text
     case real
     case blob
+    case `enum`(SQLEnumType)
     case custom(SQLExpression)
     
     public func serialize(to serializer: inout SQLSerializer) {
@@ -23,9 +24,17 @@ public enum SQLDataType: SQLExpression {
             sql = SQLRaw("REAL")
         case .blob:
             sql = SQLRaw("BLOB")
+        case .enum(let sqlEnum):
+            sql = sqlEnum
         case .custom(let expression):
             sql = expression
         }
         sql.serialize(to: &serializer)
+    }
+}
+
+extension SQLDataType {
+    public static func `enum`(name: String, values: String...) -> SQLDataType {
+        return .enum(.init(name: name, values: values))
     }
 }

--- a/Sources/SQLKit/Query/SQLEnumType.swift
+++ b/Sources/SQLKit/Query/SQLEnumType.swift
@@ -16,7 +16,7 @@ public struct SQLEnumType: SQLExpression {
 
     /// Creates a new `SQLEnumType`.
     public init(name: String, values: [String]) {
-        self.init(name: SQLRaw(name), values: values.map { SQLRaw($0) })
+        self.init(name: SQLRaw(name), values: values.map { SQLLiteral.string($0) })
     }
 
     public func serialize(to serializer: inout SQLSerializer) {

--- a/Sources/SQLKit/Query/SQLEnumType.swift
+++ b/Sources/SQLKit/Query/SQLEnumType.swift
@@ -1,31 +1,46 @@
 /// `ENUM` type.
 ///
 /// See `SQLDataType`.
-public struct SQLEnumType: SQLExpression {
+public protocol SQLEnumType: SQLExpressibleType {
     /// The name of the enum type.
-    public var name: SQLExpression
+    static var sqlTypeName: SQLExpression { get }
 
     /// The possible values of the enum type.
-    public var values: [SQLExpression]
+    ///
+    /// Commonly implemented as a `SQLGroupExpression`
+    static var sqlEnumCases: SQLExpression { get }
+}
 
-    /// Creates a new `SQLEnumType`.
-    public init(name: SQLExpression, values: [SQLExpression]) {
-        self.name = name
-        self.values = values
+extension CaseIterable where Self: RawRepresentable, Self.RawValue == String {
+    public static var sqlEnumCases: SQLExpression {
+        return SQLGroupExpression(Self.allCases.map { SQLLiteral.string($0.rawValue) })
     }
+}
 
-    /// Creates a new `SQLEnumType`.
-    public init(name: String, values: [String]) {
-        self.init(name: SQLRaw(name), values: values.map { SQLLiteral.string($0) })
+extension SQLEnumType {
+    public static var sqlExpression: SQLExpression {
+        return SQLEnum(name: Self.sqlTypeName, sqlEnumCases: Self.sqlEnumCases)
     }
+}
+
+internal struct SQLEnum: SQLExpression {
+    /// The name of the enum type.
+    var name: SQLExpression
+
+    /// The possible values of the enum type.
+    ///
+    /// Commonly implemented as a `SQLGroupExpression`
+    var sqlEnumCases: SQLExpression
 
     public func serialize(to serializer: inout SQLSerializer) {
         switch serializer.dialect.enumSyntax {
-        case .inline(literal: let literal):
-            literal.serialize(to: &serializer)
-            SQLGroupExpression(values).serialize(to: &serializer)
+        case .inline:
+            // e.g. ENUM('case1', 'case2')
+            name.serialize(to: &serializer)
+            sqlEnumCases.serialize(to: &serializer)
 
         case .typeName:
+            // e.g. WEEKDAY (can be whatever name the user creates a type for)
             name.serialize(to: &serializer)
 
         case .unsupported:

--- a/Sources/SQLKit/Query/SQLEnumType.swift
+++ b/Sources/SQLKit/Query/SQLEnumType.swift
@@ -1,0 +1,39 @@
+/// `ENUM` type.
+///
+/// See `SQLDataType`.
+public struct SQLEnumType: SQLExpression {
+    /// The name of the enum type.
+    public var name: SQLExpression
+
+    /// The possible values of the enum type.
+    public var values: [SQLExpression]
+
+    /// Creates a new `SQLEnumType`.
+    public init(name: SQLExpression, values: [SQLExpression]) {
+        self.name = name
+        self.values = values
+    }
+
+    /// Creates a new `SQLEnumType`.
+    public init(name: String, values: [String]) {
+        self.init(name: SQLRaw(name), values: values.map { SQLRaw($0) })
+    }
+
+    public func serialize(to serializer: inout SQLSerializer) {
+        switch serializer.dialect.enumSyntax {
+        case .inline(literal: let literal):
+            literal.serialize(to: &serializer)
+            SQLGroupExpression(values).serialize(to: &serializer)
+
+        case .typeName:
+            name.serialize(to: &serializer)
+
+        case .unsupported:
+            // NOTE: Consider using a CHECK constraint
+            //      with a TEXT type to verify that the
+            //      text value for a column is in a list
+            //      of possible options.
+            fatalError("ENUM types are unsupported by the current dialect.")
+        }
+    }
+}

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -7,6 +7,21 @@ public protocol SQLDialect {
     func literalBoolean(_ value: Bool) -> SQLExpression
     var literalDefault: SQLExpression { get }
     var supportsIfExists: Bool { get }
+
+    var enumSyntax: SQLEnumSyntax { get }
+}
+
+public enum SQLEnumSyntax {
+    /// for ex. MySQL, which uses the ENUM literal followed by the options
+    case inline(literal: SQLExpression)
+
+    /// for ex. PostgreSQL, which uses the name of type that must have been
+    /// previously created.
+    case typeName
+
+    /// for ex. SQL Server, which does not have an enum syntax.
+    /// - note: you can likely simulate an enum with a CHECK constraint.
+    case unsupported
 }
 
 extension SQLDialect {

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -13,7 +13,7 @@ public protocol SQLDialect {
 
 public enum SQLEnumSyntax {
     /// for ex. MySQL, which uses the ENUM literal followed by the options
-    case inline(literal: SQLExpression)
+    case inline
 
     /// for ex. PostgreSQL, which uses the name of type that must have been
     /// previously created.

--- a/Sources/SQLKit/SQLExpressibleType.swift
+++ b/Sources/SQLKit/SQLExpressibleType.swift
@@ -1,0 +1,4 @@
+
+public protocol SQLExpressibleType {
+    static var sqlExpression: SQLExpression { get }
+}

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -60,6 +60,25 @@ final class SQLKitTests: XCTestCase {
         try db.drop(table: "planets").ifExists().run().wait()
         XCTAssertEqual(db.results[1], "DROP TABLE `planets`")
     }
+
+    func testEnumType() throws {
+        let db = TestDatabase()
+
+        // ensure test is using inline enum syntax
+        db._dialect.enumSyntax = .inline(literal: SQLRaw("ENUM"))
+
+        try db.create(table: "planets")
+            .column("size", type: .enum(name: "size", values: "small", "medium", "large"))
+            .run().wait()
+        XCTAssertEqual(db.results[0], "CREATE TABLE `planets`(`size` ENUM('small', 'medium', 'large'))")
+
+        db._dialect.enumSyntax = .typeName
+
+        try db.create(table: "planets")
+            .column("size", type: .enum(name: "SIZE", values: "small", "medium", "large"))
+            .run().wait()
+        XCTAssertEqual(db.results[1], "CREATE TABLE `planets`(`size` SIZE)")
+    }
 }
 
 // MARK: Table Creation

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -72,6 +72,7 @@ final class SQLKitTests: XCTestCase {
             .run().wait()
         XCTAssertEqual(db.results[0], "CREATE TABLE `planets`(`size` ENUM('small', 'medium', 'large'))")
 
+        // switch to type name enum syntax
         db._dialect.enumSyntax = .typeName
 
         try db.create(table: "planets")

--- a/Tests/SQLKitTests/Utilities.swift
+++ b/Tests/SQLKitTests/Utilities.swift
@@ -50,6 +50,8 @@ struct GenericDialect: SQLDialect {
         case false: return SQLRaw("false")
         }
     }
+
+    var enumSyntax: SQLEnumSyntax = .inline(literal: SQLRaw("ENUM"))
     
     var autoIncrementClause: SQLExpression {
         return SQLRaw("AUTOINCREMENT")

--- a/Tests/SQLKitTests/Utilities.swift
+++ b/Tests/SQLKitTests/Utilities.swift
@@ -25,6 +25,53 @@ final class TestDatabase: SQLDatabase {
     }
 }
 
+struct TestRow: SQLRow {
+    var data: [String: Any]
+
+    enum _Error: Error {
+        case missingColumn(String)
+        case typeMismatch(Any, Any.Type)
+    }
+
+    var allColumns: [String] {
+        .init(self.data.keys)
+    }
+
+    func contains(column: String) -> Bool {
+        self.data.keys.contains(column)
+    }
+
+    func decodeNil(column: String) throws -> Bool {
+        if let value = self.data[column], let optional = value as? OptionalType {
+            return optional.isNil
+        } else {
+            return false
+        }
+    }
+
+    func decode<D>(column: String, as type: D.Type) throws -> D
+        where D : Decodable
+    {
+        guard let value = self.data[column] else {
+            throw _Error.missingColumn(column)
+        }
+        guard let cast = value as? D else {
+            throw _Error.typeMismatch(value, D.self)
+        }
+        return cast
+    }
+}
+
+protocol OptionalType {
+    var isNil: Bool { get }
+}
+
+extension Optional: OptionalType {
+    var isNil: Bool {
+        self == nil
+    }
+}
+
 struct GenericDialect: SQLDialect {
     var name: String {
         "generic sql"
@@ -51,9 +98,44 @@ struct GenericDialect: SQLDialect {
         }
     }
 
-    var enumSyntax: SQLEnumSyntax = .inline(literal: SQLRaw("ENUM"))
+    var enumSyntax: SQLEnumSyntax = .inline
     
     var autoIncrementClause: SQLExpression {
         return SQLRaw("AUTOINCREMENT")
     }
+}
+
+protocol MySQLEnum: SQLEnumType {}
+extension MySQLEnum {
+    static var sqlTypeName: SQLExpression { SQLRaw("ENUM") }
+}
+
+enum TestMySQLEnum: String, CaseIterable, MySQLEnum {
+    case small
+    case medium
+    case large
+}
+
+enum TestPostgresEnum: String, CaseIterable, SQLEnumType {
+    static let sqlTypeName: SQLExpression = SQLRaw("SIZE")
+
+    case small
+    case medium
+    case large
+}
+
+protocol FluentEnum: SQLEnumType {
+    static var name: String { get }
+}
+
+extension FluentEnum {
+    static var sqlTypeName: SQLExpression { SQLRaw(name) }
+}
+
+enum TestFluentEnum: String, CaseIterable, FluentEnum {
+    static let name = "SIZE"
+
+    case small
+    case medium
+    case large
 }


### PR DESCRIPTION
Closes https://github.com/vapor/sql-kit/issues/80
See conversation at https://github.com/vapor/sql-kit/pull/81 for context.

## Summary of differences:
### No direct support for enums on `SQLDataType`
Support for enums on `SQLDataType` were removed because there is no one-size-fits all approach to enums and this leads to a confusing implementation of strictly-SQL enums.

### `SQLEnumType` becomes a protocol
`SQLEnumType` and `SQLEnumSyntax` remain so that `MySQLKit` and family can enjoy a shared implementation of enum serialization, `PostgresKit` gets out-of-box support for enum serialization, and `FluentKit` can provide enum support without re-implementing the details conditional upon the dialect being used.

The implementation details of `SQLEnumType` were moved into an internal type named `SQLEnum`. `SQLEnumType` is now a public protocol. The protocol requires a SQL enum name and the names of all the enum's cases, but it is intended to be wrapped by more specific libraries to provide additional more specialized protocols to which end-users are encouraged to conform their own Swift enums. 

Importantly, the switch from the end-user creating _values_ representing enums to _types_ representing enums all-but-entirely removes the confusion around all enums having both a name and cases defined even though:
1. In Postgres you will use those two pieces of information in different locations (serializing a new type to create an enum and serializing that type's name to reference from a table).
2. In MySQL-like dialects the name will always be "ENUM" and the cases will be serialized inline in the table.

## Ergonomics of now-possible PostgresKit/MySQLKit changes
In MySQLKit, the following protocol and extensions can be created:
```swift
public protocol MySQLEnum: SQLEnumType {}
extension MySQLEnum {
    public static var sqlTypeName: SQLExpression { SQLRaw("ENUM") }
}

extension SQLDataType {
    public static func `enum`<T: MySQLEnum>(_ type: T.Type) -> SQLDataType {
        return .custom(T.sqlExpression)
    }
}
```
This allows the end user to create and use enums like
```swift
enum TestMySQLEnum: String, CaseIterable, MySQLEnum {
    case small
    case medium
    case large
}

try db.create(table: "planets")
    .column("size", type: .enum(TestMySQLEnum.self))
```

In PostgresKit, the following extensions can be created:
```swift
extension SQLDataType {
    public static func `enum`<T: SQLEnumType>(_ type: T.Type) -> SQLDataType {
        return .custom(T.sqlExpression)
    }
}

// this could potentially just replace the existing methods for creating enum types in PostgresKit
extension SQLDatabase {
    public func create<T: SQLEnumType>(enum type: T.Type) -> PostgresCreateTypeBuilder {
        return .init(.enum(name: T.sqlTypeName, cases: T.sqlEnumCases), on: self)
    } 
}
```
This allows the end user to create and use enums like
```swift
enum TestPostgresEnum: String, CaseIterable, SQLEnumType {
    static let sqlTypeName: SQLExpression = SQLRaw("SIZE")

    case small
    case medium
    case large
}

try db.create(enum: TestPostgresEnum.self).run().wait()
try db.create(table: "planets")
    .column("size", type: .enum(TestPostgresEnum.self))
    .run().wait()
```

## Ergonomics of now-possible FluentKit changes
In FluentKit, the following protocol and extensions (and some other tweaks) are roughly in line with discussion at https://github.com/vapor/fluent-kit/issues/39
```swift
public protocol DatabaseEnum: SQLEnumType {
    static var name: String { get }
}

extension DatabaseEnum {
    public static var sqlTypeName: SQLExpression { SQLRaw(name) }
}
```
This allows the end user to create enums like
```swift
enum TestFluentEnum: String, CaseIterable, DatabaseEnum {
    static let name = "SIZE"

    case small
    case medium
    case large
}

try db.create(enum: TestFluentEnum.self).run().flatMap {
    Planet.schema(on: db)
        .field(\.size, .enum(TestFluentEnum.self))
        .create()
}
```
The only difference between the above example and the one mentioned in the existing FluentKit ticket for enum support is support for `DatabaseEnum.create(on:)`; as far as I can think this would need to be added somewhere that imported both FluentKit and PostgresKit (to get access to PostgresKit's type creation facilities) -- would that be best in FluentPostgresDriver?