### PR TITLE
Adds support for a drop table behavior clause

### DIFF
--- a/Sources/SQLKit/Builders/SQLDropTableBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLDropTableBuilder.swift
@@ -30,8 +30,8 @@ public final class SQLDropTableBuilder: SQLQueryBuilder {
 
     /// The optional `IF EXISTS` clause suppresses the error that would normally
     /// result if the table does not exist.
-    public func behaviour(_ behaviour: SQLDropBehaviour) -> Self {
-        dropTable.behaviour = behaviour
+    public func behavior(_ behavior: SQLDropBehavior) -> Self {
+        dropTable.behavior = behavior
         return self
     }
 }

--- a/Sources/SQLKit/Builders/SQLDropTableBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLDropTableBuilder.swift
@@ -28,10 +28,25 @@ public final class SQLDropTableBuilder: SQLQueryBuilder {
         return self
     }
 
-    /// The optional `IF EXISTS` clause suppresses the error that would normally
-    /// result if the table does not exist.
+    /// The drop behavior clause specifies if objects that depend on a table
+    /// should also be dropped or not when the table is dropped, for databases
+    /// that supports this.
     public func behavior(_ behavior: SQLDropBehavior) -> Self {
         dropTable.behavior = behavior
+        return self
+    }
+
+    /// Adds a `CASCADE` clause to the `DROP TABLE` statement instructing that
+    /// objects that depends on this table should also be dropped.
+    public func cascade() -> Self {
+        dropTable.behavior = SQLDropBehavior.cascade
+        return self
+    }
+
+    /// Adds a `RESTRICT` clause to the `DROP TABLE` statement instructing that
+    /// if any objects depends on this table, the drop should be refused.
+    public func restrict() -> Self {
+        dropTable.behavior = SQLDropBehavior.restrict
         return self
     }
 }

--- a/Sources/SQLKit/Builders/SQLDropTableBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLDropTableBuilder.swift
@@ -27,6 +27,13 @@ public final class SQLDropTableBuilder: SQLQueryBuilder {
         dropTable.ifExists = true
         return self
     }
+
+    /// The optional `IF EXISTS` clause suppresses the error that would normally
+    /// result if the table does not exist.
+    public func behaviour(_ behaviour: SQLDropBehaviour) -> Self {
+        dropTable.behaviour = behaviour
+        return self
+    }
 }
 
 // MARK: Connection

--- a/Sources/SQLKit/Query/SQLDropBehaviour.swift
+++ b/Sources/SQLKit/Query/SQLDropBehaviour.swift
@@ -1,0 +1,18 @@
+/// RESTRICT | CASCADE
+public enum SQLDropBehaviour: SQLExpression {
+    /// The drop behaviour clause specifies if objects that depend on a table
+    /// should also be dropped or not when the table is dropped.
+    
+    /// Refuse to drop the table if any objects depend on it.
+    case restrict
+    
+    /// Automatically drop objects that depend on the table (such as views).
+    case cascade
+    
+    public func serialize(to serializer: inout SQLSerializer) {
+        switch self {
+        case .restrict: serializer.write("RESTRICT")
+        case .cascade: serializer.write("CASCADE")
+        }
+    }
+}

--- a/Sources/SQLKit/Query/SQLDropBehaviour.swift
+++ b/Sources/SQLKit/Query/SQLDropBehaviour.swift
@@ -1,6 +1,6 @@
 /// RESTRICT | CASCADE
-public enum SQLDropBehaviour: SQLExpression {
-    /// The drop behaviour clause specifies if objects that depend on a table
+public enum SQLDropBehavior: SQLExpression {
+    /// The drop behavior clause specifies if objects that depend on a table
     /// should also be dropped or not when the table is dropped.
     
     /// Refuse to drop the table if any objects depend on it.

--- a/Sources/SQLKit/Query/SQLDropTable.swift
+++ b/Sources/SQLKit/Query/SQLDropTable.swift
@@ -9,10 +9,10 @@ public struct SQLDropTable: SQLExpression {
     /// result if the table does not exist.
     public var ifExists: Bool
 
-    /// The optional drop behaviour clause specifies if objects that depend on the
+    /// The optional drop behavior clause specifies if objects that depend on the
     /// table should also be dropped or not, for databases that supports this
     /// (either `CASCADE` or `RESTRICT`).
-    public var behaviour: SQLExpression?
+    public var behavior: SQLExpression?
 
     /// Creates a new `SQLDropTable`.
     public init(table: SQLExpression) {
@@ -31,12 +31,12 @@ public struct SQLDropTable: SQLExpression {
             }
         }
         self.table.serialize(to: &serializer)
-        if serializer.dialect.supportsDropBehaviour {
+        if serializer.dialect.supportsDropBehavior {
             serializer.write(" ")
-            if let dropBehaviour = behaviour {
-                dropBehaviour.serialize(to: &serializer)
+            if let dropBehavior = behavior {
+                dropBehavior.serialize(to: &serializer)
             } else {
-                SQLDropBehaviour.cascade.serialize(to: &serializer)
+                SQLDropBehavior.cascade.serialize(to: &serializer)
             }
         }
     }

--- a/Sources/SQLKit/Query/SQLDropTable.swift
+++ b/Sources/SQLKit/Query/SQLDropTable.swift
@@ -8,7 +8,12 @@ public struct SQLDropTable: SQLExpression {
     /// The optional `IF EXISTS` clause suppresses the error that would normally
     /// result if the table does not exist.
     public var ifExists: Bool
-    
+
+    /// The optional drop behaviour clause specifies if objects that depend on the
+    /// table should also be dropped or not, for databases that supports this
+    /// (either `CASCADE` or `RESTRICT`).
+    public var behaviour: SQLExpression?
+
     /// Creates a new `SQLDropTable`.
     public init(table: SQLExpression) {
         self.table = table
@@ -26,5 +31,13 @@ public struct SQLDropTable: SQLExpression {
             }
         }
         self.table.serialize(to: &serializer)
+        if serializer.dialect.supportsDropBehaviour {
+            serializer.write(" ")
+            if let dropBehaviour = behaviour {
+                dropBehaviour.serialize(to: &serializer)
+            } else {
+                SQLDropBehaviour.cascade.serialize(to: &serializer)
+            }
+        }
     }
 }

--- a/Sources/SQLKit/Query/SQLDropTable.swift
+++ b/Sources/SQLKit/Query/SQLDropTable.swift
@@ -36,7 +36,7 @@ public struct SQLDropTable: SQLExpression {
             if let dropBehavior = behavior {
                 dropBehavior.serialize(to: &serializer)
             } else {
-                SQLDropBehavior.cascade.serialize(to: &serializer)
+                SQLDropBehavior.restrict.serialize(to: &serializer)
             }
         }
     }

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -9,6 +9,7 @@ public protocol SQLDialect {
     var supportsIfExists: Bool { get }
     var supportsAutoIncrement: Bool { get }
     var enumSyntax: SQLEnumSyntax { get }
+    var supportsDropBehaviour: Bool { get }
 }
 
 public enum SQLEnumSyntax {
@@ -31,5 +32,9 @@ extension SQLDialect {
 
     public var supportsIfExists: Bool {
         return true
+    }
+
+    public var supportsDropBehaviour: Bool {
+        return false
     }
 }

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -9,7 +9,7 @@ public protocol SQLDialect {
     var supportsIfExists: Bool { get }
     var supportsAutoIncrement: Bool { get }
     var enumSyntax: SQLEnumSyntax { get }
-    var supportsDropBehaviour: Bool { get }
+    var supportsDropBehavior: Bool { get }
 }
 
 public enum SQLEnumSyntax {
@@ -34,7 +34,7 @@ extension SQLDialect {
         return true
     }
 
-    public var supportsDropBehaviour: Bool {
+    public var supportsDropBehavior: Bool {
         return false
     }
 }

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -82,6 +82,7 @@ extension SQLDialect {
 
     public var supportsDropBehavior: Bool {
         return false
+    }
 
     public var triggerSyntax: SQLTriggerSyntax {
         return SQLTriggerSyntax()

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -73,15 +73,27 @@ final class SQLKitTests: XCTestCase {
         try db.drop(table: "planets").behavior(.restrict).run().wait()
         XCTAssertEqual(db.results[2], "DROP TABLE `planets`")
 
+        try db.drop(table: "planets").cascade().run().wait()
+        XCTAssertEqual(db.results[3], "DROP TABLE `planets`")
+
+        try db.drop(table: "planets").restrict().run().wait()
+        XCTAssertEqual(db.results[4], "DROP TABLE `planets`")
+
         db._dialect.supportsDropBehavior = true
         try db.drop(table: "planets").run().wait()
-        XCTAssertEqual(db.results[3], "DROP TABLE `planets` CASCADE")
+        XCTAssertEqual(db.results[5], "DROP TABLE `planets` CASCADE")
 
         try db.drop(table: "planets").behavior(.cascade).run().wait()
-        XCTAssertEqual(db.results[4], "DROP TABLE `planets` CASCADE")
+        XCTAssertEqual(db.results[6], "DROP TABLE `planets` CASCADE")
 
         try db.drop(table: "planets").behavior(.restrict).run().wait()
-        XCTAssertEqual(db.results[5], "DROP TABLE `planets` RESTRICT")
+        XCTAssertEqual(db.results[7], "DROP TABLE `planets` RESTRICT")
+
+        try db.drop(table: "planets").cascade().run().wait()
+        XCTAssertEqual(db.results[8], "DROP TABLE `planets` CASCADE")
+
+        try db.drop(table: "planets").restrict().run().wait()
+        XCTAssertEqual(db.results[9], "DROP TABLE `planets` RESTRICT")
     }
 }
 

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -61,26 +61,26 @@ final class SQLKitTests: XCTestCase {
         XCTAssertEqual(db.results[1], "DROP TABLE `planets`")
     }
 
-    func testDropBehaviour() throws {
+    func testDropBehavior() throws {
         let db = TestDatabase()
 
         try db.drop(table: "planets").run().wait()
         XCTAssertEqual(db.results[0], "DROP TABLE `planets`")
 
-        try db.drop(table: "planets").behaviour(.cascade).run().wait()
+        try db.drop(table: "planets").behavior(.cascade).run().wait()
         XCTAssertEqual(db.results[1], "DROP TABLE `planets`")
 
-        try db.drop(table: "planets").behaviour(.restrict).run().wait()
+        try db.drop(table: "planets").behavior(.restrict).run().wait()
         XCTAssertEqual(db.results[2], "DROP TABLE `planets`")
 
-        db._dialect.supportsDropBehaviour = true
+        db._dialect.supportsDropBehavior = true
         try db.drop(table: "planets").run().wait()
         XCTAssertEqual(db.results[3], "DROP TABLE `planets` CASCADE")
 
-        try db.drop(table: "planets").behaviour(.cascade).run().wait()
+        try db.drop(table: "planets").behavior(.cascade).run().wait()
         XCTAssertEqual(db.results[4], "DROP TABLE `planets` CASCADE")
 
-        try db.drop(table: "planets").behaviour(.restrict).run().wait()
+        try db.drop(table: "planets").behavior(.restrict).run().wait()
         XCTAssertEqual(db.results[5], "DROP TABLE `planets` RESTRICT")
     }
 }

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -60,6 +60,29 @@ final class SQLKitTests: XCTestCase {
         try db.drop(table: "planets").ifExists().run().wait()
         XCTAssertEqual(db.results[1], "DROP TABLE `planets`")
     }
+
+    func testDropBehaviour() throws {
+        let db = TestDatabase()
+
+        try db.drop(table: "planets").run().wait()
+        XCTAssertEqual(db.results[0], "DROP TABLE `planets`")
+
+        try db.drop(table: "planets").behaviour(.cascade).run().wait()
+        XCTAssertEqual(db.results[1], "DROP TABLE `planets`")
+
+        try db.drop(table: "planets").behaviour(.restrict).run().wait()
+        XCTAssertEqual(db.results[2], "DROP TABLE `planets`")
+
+        db._dialect.supportsDropBehaviour = true
+        try db.drop(table: "planets").run().wait()
+        XCTAssertEqual(db.results[3], "DROP TABLE `planets` CASCADE")
+
+        try db.drop(table: "planets").behaviour(.cascade).run().wait()
+        XCTAssertEqual(db.results[4], "DROP TABLE `planets` CASCADE")
+
+        try db.drop(table: "planets").behaviour(.restrict).run().wait()
+        XCTAssertEqual(db.results[5], "DROP TABLE `planets` RESTRICT")
+    }
 }
 
 // MARK: Table Creation

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -81,7 +81,7 @@ final class SQLKitTests: XCTestCase {
 
         db._dialect.supportsDropBehavior = true
         try db.drop(table: "planets").run().wait()
-        XCTAssertEqual(db.results[5], "DROP TABLE `planets` CASCADE")
+        XCTAssertEqual(db.results[5], "DROP TABLE `planets` RESTRICT")
 
         try db.drop(table: "planets").behavior(.cascade).run().wait()
         XCTAssertEqual(db.results[6], "DROP TABLE `planets` CASCADE")

--- a/Tests/SQLKitTests/Utilities.swift
+++ b/Tests/SQLKitTests/Utilities.swift
@@ -108,5 +108,5 @@ struct GenericDialect: SQLDialect {
         return SQLRaw("AUTOINCREMENT")
     }
 
-    var supportsDropBehaviour: Bool = false
+    var supportsDropBehavior: Bool = false
 }

--- a/Tests/SQLKitTests/Utilities.swift
+++ b/Tests/SQLKitTests/Utilities.swift
@@ -107,4 +107,6 @@ struct GenericDialect: SQLDialect {
     var autoIncrementClause: SQLExpression {
         return SQLRaw("AUTOINCREMENT")
     }
+
+    var supportsDropBehaviour: Bool = false
 }


### PR DESCRIPTION
In SQL 92, the drop behavior, either RESTRICT or CASCADE is mandatory after the table name. Some databases requires either one of them to be present in a DROP TABLE statement, and there’s no way to specify that in sql-kit.

Intended to resolve issue #64.