### PR TITLE
Add optional autoincrement function expression to SQLDialect

### DIFF
--- a/Sources/SQLKit/Query/SQLColumnConstraintAlgorithm.swift
+++ b/Sources/SQLKit/Query/SQLColumnConstraintAlgorithm.swift
@@ -93,21 +93,24 @@ public enum SQLColumnConstraintAlgorithm: SQLExpression {
         switch self {
         case .primaryKey(let autoIncrement):
             if autoIncrement {
-                if serializer.database.dialect.supportsAutoIncrementUsingDefaultFunction{
-                    serializer.dialect.literalDefault.serialize(to: &serializer)
-                    serializer.write(" ")
-                    serializer.dialect.autoIncrementFunction.serialize(to: &serializer)
-                    serializer.write(" ")
-                }
-            }
-            serializer.write("PRIMARY KEY")
-            if autoIncrement {
                 if serializer.database.dialect.supportsAutoIncrement {
-                    serializer.write(" ")
-                    serializer.dialect.autoIncrementClause.serialize(to: &serializer)
-                } else if !serializer.database.dialect.supportsAutoIncrementUsingDefaultFunction {
+                    if let function = serializer.database.dialect.autoIncrementFunction {
+                        serializer.dialect.literalDefault.serialize(to: &serializer)
+                        serializer.write(" ")
+                        function.serialize(to: &serializer)
+                        serializer.write(" ")
+                        serializer.write("PRIMARY KEY")
+                    } else {
+                        serializer.write("PRIMARY KEY")
+                        serializer.write(" ")
+                        serializer.dialect.autoIncrementClause.serialize(to: &serializer)
+                    }
+                } else {
                     serializer.database.logger.warning("Autoincrement not supported, skipping")
+                    serializer.write("PRIMARY KEY")
                 }
+            } else {
+                serializer.write("PRIMARY KEY")
             }
         case .notNull:
             serializer.write("NOT NULL")

--- a/Sources/SQLKit/Query/SQLColumnConstraintAlgorithm.swift
+++ b/Sources/SQLKit/Query/SQLColumnConstraintAlgorithm.swift
@@ -92,12 +92,20 @@ public enum SQLColumnConstraintAlgorithm: SQLExpression {
     public func serialize(to serializer: inout SQLSerializer) {
         switch self {
         case .primaryKey(let autoIncrement):
+            if autoIncrement {
+                if serializer.database.dialect.supportsAutoIncrementUsingDefaultFunction{
+                    serializer.dialect.literalDefault.serialize(to: &serializer)
+                    serializer.write(" ")
+                    serializer.dialect.autoIncrementFunction.serialize(to: &serializer)
+                    serializer.write(" ")
+                }
+            }
             serializer.write("PRIMARY KEY")
             if autoIncrement {
                 if serializer.database.dialect.supportsAutoIncrement {
                     serializer.write(" ")
                     serializer.dialect.autoIncrementClause.serialize(to: &serializer)
-                } else {
+                } else if !serializer.database.dialect.supportsAutoIncrementUsingDefaultFunction {
                     serializer.database.logger.warning("Autoincrement not supported, skipping")
                 }
             }

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -8,8 +8,7 @@ public protocol SQLDialect {
     var literalDefault: SQLExpression { get }
     var supportsIfExists: Bool { get }
     var supportsAutoIncrement: Bool { get }
-    var supportsAutoIncrementUsingDefaultFunction: Bool { get }
-    var autoIncrementFunction: SQLExpression { get }
+    var autoIncrementFunction: SQLExpression? { get }
     var enumSyntax: SQLEnumSyntax { get }
 }
 
@@ -35,11 +34,7 @@ extension SQLDialect {
         return true
     }
 
-    public var supportsAutoIncrementUsingDefaultFunction: Bool {
-        return false
-    }
-
-    public var autoIncrementFunction: SQLExpression {
-        return SQLRaw("")
+    public var autoIncrementFunction: SQLExpression? {
+        return nil
     }
 }

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -8,6 +8,8 @@ public protocol SQLDialect {
     var literalDefault: SQLExpression { get }
     var supportsIfExists: Bool { get }
     var supportsAutoIncrement: Bool { get }
+    var supportsAutoIncrementUsingDefaultFunction: Bool { get }
+    var autoIncrementFunction: SQLExpression { get }
     var enumSyntax: SQLEnumSyntax { get }
 }
 
@@ -31,5 +33,13 @@ extension SQLDialect {
 
     public var supportsIfExists: Bool {
         return true
+    }
+
+    public var supportsAutoIncrementUsingDefaultFunction: Bool {
+        return false
+    }
+
+    public var autoIncrementFunction: SQLExpression {
+        return SQLRaw("")
     }
 }

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -112,6 +112,37 @@ CREATE TABLE `planets`(`id` BIGINT PRIMARY KEY AUTOINCREMENT, `name` TEXT DEFAUL
         XCTAssertEqual(db.results[1], "CREATE TABLE `planets2`(`id` BIGINT PRIMARY KEY)")
     }
 
+    func testPrimaryKeyAutoIncrementVariants() throws {
+        let db = TestDatabase()
+
+        try db.create(table: "planets1")
+            .column("id", type: .bigint, .primaryKey)
+            .run().wait()
+
+        try db.create(table: "planets2")
+            .column("id", type: .bigint, .primaryKey(autoIncrement: false))
+            .run().wait()
+
+        db._dialect.supportsAutoIncrementUsingDefaultFunction = true
+        db._dialect.supportsAutoIncrement = false
+
+        try db.create(table: "planets3")
+            .column("id", type: .bigint, .primaryKey)
+            .run().wait()
+
+        try db.create(table: "planets4")
+            .column("id", type: .bigint, .primaryKey(autoIncrement: false))
+            .run().wait()
+
+        XCTAssertEqual(db.results[0], "CREATE TABLE `planets1`(`id` BIGINT PRIMARY KEY AUTOINCREMENT)")
+
+        XCTAssertEqual(db.results[1], "CREATE TABLE `planets2`(`id` BIGINT PRIMARY KEY)")
+
+        XCTAssertEqual(db.results[2], "CREATE TABLE `planets3`(`id` BIGINT DEFAULT NEXTUNIQUE PRIMARY KEY)")
+
+        XCTAssertEqual(db.results[3], "CREATE TABLE `planets4`(`id` BIGINT PRIMARY KEY)")
+    }
+
     func testDefaultColumnConstraintVariants() throws {
         let db = TestDatabase()
 

--- a/Tests/SQLKitTests/Utilities.swift
+++ b/Tests/SQLKitTests/Utilities.swift
@@ -105,10 +105,6 @@ struct GenericDialect: SQLDialect {
     var autoIncrementClause: SQLExpression {
         return SQLRaw("AUTOINCREMENT")
     }
-    
-    var supportsAutoIncrementUsingDefaultFunction: Bool = false
 
-    var autoIncrementFunction: SQLExpression {
-        return SQLRaw("NEXTUNIQUE")
-    }
+    var autoIncrementFunction: SQLExpression? = nil
 }

--- a/Tests/SQLKitTests/Utilities.swift
+++ b/Tests/SQLKitTests/Utilities.swift
@@ -73,9 +73,7 @@ extension Optional: OptionalType {
 }
 
 struct GenericDialect: SQLDialect {
-    var supportsAutoIncrement: Bool {
-        true
-    }
+    var supportsAutoIncrement: Bool = true
 
     var name: String {
         "generic sql"
@@ -106,5 +104,11 @@ struct GenericDialect: SQLDialect {
     
     var autoIncrementClause: SQLExpression {
         return SQLRaw("AUTOINCREMENT")
+    }
+    
+    var supportsAutoIncrementUsingDefaultFunction: Bool = false
+
+    var autoIncrementFunction: SQLExpression {
+        return SQLRaw("NEXTUNIQUE")
     }
 }


### PR DESCRIPTION
Some databases doesn’t support the `AUTOINCREMENT` clause, but have the ability to implement autoincrementing primary keys using a function as a default instead.