### PR TITLE
Initial support for UPSERT.

### DIFF
--- a/Sources/SQLKit/Builders/SQLConflictUpdateBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLConflictUpdateBuilder.swift
@@ -1,0 +1,59 @@
+/// Not intended for direct use by clients. Builds UPDATE clauses to be used in
+/// UPSERT queries.
+///
+/// - TODO: Factor out common code in this class and `SQLUpdateBuilder` instead of repeating everthing.
+public final class SQLConflictUpdateBuilder: SQLQueryBuilder, SQLPredicateBuilder {
+
+    /// `Update` query being built.
+    public var update: SQLUpdate
+
+    /// See `SQLQueryBuilder`.
+    public var database: SQLDatabase
+    
+    /// See `SQLQueryBuilder`.
+    public var query: SQLExpression {
+        return self.update
+    }
+    
+    /// See `SQLPredicateBuilder`.
+    public var predicate: SQLExpression? {
+        get { return self.update.predicate }
+        set { self.update.predicate = newValue }
+    }
+    
+    /// Creates a new `SQLConflictUpdateBuilder`.
+    public init(_ update: SQLUpdate, on database: SQLDatabase) {
+        self.update = update
+        self.database = database
+    }
+
+    public func set<E>(model: E) throws -> Self where E: Encodable {
+        self.update.values += try SQLUpdateBuilder(.init(table: SQLIdentifier("")), on: self.database).set(model: model).update.values
+        return self
+    }
+
+    public func set(_ column: String, to bind: Encodable) -> Self {
+        return self.set(SQLIdentifier(column), to: SQLBind(bind))
+    }
+
+    public func set(_ column: SQLExpression, to value: SQLExpression) -> Self {
+        let binary = SQLBinaryExpression(left: column, op: SQLBinaryOperator.equal, right: value)
+        self.update.values.append(binary)
+        return self
+    }
+
+    /// Set a column to the value which would have been inserted if a conflict
+    /// had not occurred. This method should only be called on update builders
+    /// used for an upsert.
+    public func set(excudedValueOf column: String) -> Self {
+        return self.set(SQLIdentifier(column), to: SQLExcludedColumn(column))
+    }
+    
+    /// Set a column to the value which would have been inserted if a conflict
+    /// had not occurred. This method should only be called on update builders
+    /// used for an upsert.
+    public func set(excludedValueOf column: SQLExpression) -> Self {
+        return self.set(column, to: SQLExcludedColumn(column))
+    }
+
+}

--- a/Sources/SQLKit/Builders/SQLUpsertBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLUpsertBuilder.swift
@@ -1,0 +1,114 @@
+/// Builds `SQLInsert` queries with conflict resolution clauses ("upserts").
+///
+///     conn.upsert(Planet.self)
+///         .model(earth)
+///         .onConflict(with: ["id"], where: { $0.where(\Planet.type == .smallRocky) }) {
+///             $0.set(SQLColumn("name", table: Planet.schema), to: SQLColumn("name", table: "excluded"))
+///         }
+///         .run()
+///
+/// See `SQLInsertBuilder`, `SQLUpdateBuilder`, and `SQLPredicateBuilder` for
+/// more information.
+public final class SQLUpsertBuilder: SQLQueryBuilder {
+    
+    /// Upsert query being built.
+    public var upsert: SQLUpsert
+    
+    /// See `SQLQueryBuilder`.
+    public var database: SQLDatabase
+    
+    /// See `SQLQueryBuilder`.
+    public var query: SQLExpression {
+        return self.upsert
+    }
+    
+    /// Creates a new `SQLUpsertBuilder`.
+    public init(_ upsert: SQLUpsert, on database: SQLDatabase) {
+        self.upsert = upsert
+        self.database = database
+    }
+    
+    /// See `SQLInsertBuilder.model(_:)`
+    public func model<E>(_ model: E) throws -> Self
+        where E: Encodable
+    {
+        // This silly hack avoids duplicating the implementation of this method
+        // found in `SQLInsertBuilder`. There's probably a better way.
+        self.upsert.insert.values.append(
+            try SQLInsertBuilder(.init(table: SQLIdentifier("")), on: self.database).model(model).insert.values[0]
+        )
+        return self
+    }
+
+    public func columns(_ columns: String...) -> Self {
+        self.upsert.insert.columns = columns.map(SQLIdentifier.init)
+        return self
+    }
+    
+    public func columns(_ columns: SQLExpression...) -> Self {
+        self.upsert.insert.columns = columns
+        return self
+    }
+    
+    public func values(_ values: Encodable...) -> Self {
+        let row: [SQLExpression] = values.map(SQLBind.init)
+        self.upsert.insert.values.append(row)
+        return self
+    }
+    
+    public func values(_ values: SQLExpression...) -> Self {
+        self.upsert.insert.values.append(values)
+        return self
+    }
+    
+    public func onConflict(
+        with targets: [String],
+        where predicate: ((SQLPredicateBuilder) -> SQLPredicateBuilder)? = nil,
+        `do` updatePredicate: (SQLConflictUpdateBuilder) -> SQLConflictUpdateBuilder
+    ) -> Self {
+        self.upsert.targets = targets.map(SQLIdentifier.init)
+        self.upsert.condition = predicate?(SQLPredicateGroupBuilder()).predicate
+        self.upsert.action = SQLConflictAction.update(updatePredicate(.init(.init(table: SQLRaw("")), on: self.database)).update)
+        return self
+    }
+
+    public func onConflict(
+        with targets: [SQLExpression],
+        where predicate: SQLExpression? = nil,
+        update: SQLExpression
+    ) -> Self {
+        self.upsert.targets = targets
+        self.upsert.condition = predicate
+        self.upsert.action = update
+        return self
+    }
+    
+}
+
+// MARK: Connection
+
+extension SQLDatabase {
+
+    /// Creates a new `SQLUpsertBuilder`.
+    ///
+    ///     conn.upsert(into: "planets")...
+    ///
+    /// - parameters:
+    ///     - table: Table to insert into.
+    /// - returns: Newly created `SQLUpsertBuilder`.
+    public func upsert(into table: String) -> SQLUpsertBuilder {
+        return self.upsert(into: SQLIdentifier(table))
+    }
+    
+    /// Creates a new `SQLUpsertBuilder`.
+    ///
+    ///     conn.upsert(into: "planets")...
+    ///
+    /// - parameters:
+    ///     - table: Table to insert into.
+    /// - returns: Newly created `SQLUpsertBuilder`.
+    public func upsert(into table: SQLExpression) -> SQLUpsertBuilder {
+        return .init(.init(table: table), on: self)
+    }
+
+}

--- a/Sources/SQLKit/Query/SQLConflictAction.swift
+++ b/Sources/SQLKit/Query/SQLConflictAction.swift
@@ -1,0 +1,15 @@
+public enum SQLConflictAction: SQLExpression {
+    case nothing
+    case update(SQLUpdate)
+    
+    public func serialize(to serializer: inout SQLSerializer) {
+        switch self {
+            case .nothing: serializer.write("DO NOTHING")
+            case .update(var u):
+                serializer.write("DO ")
+                // - TODO: This results in the serialized string "DO UPDATE  SET". Figure out a means of eliding the extra whitespace.
+                u.table = SQLRaw("")
+                u.serialize(to: &serializer)
+        }
+    }
+}

--- a/Sources/SQLKit/Query/SQLExcludedColumn.swift
+++ b/Sources/SQLKit/Query/SQLExcludedColumn.swift
@@ -1,0 +1,16 @@
+public struct SQLExcludedColumn: SQLExpression {
+    public var name: SQLExpression
+    
+    public init(_ name: String) {
+        self.init(SQLIdentifier(name))
+    }
+    
+    public init(_ name: SQLExpression) {
+        self.name = name
+    }
+    
+    public func serialize(to serializer: inout SQLSerializer) {
+        // serializer.dialect.excludedValueExpression(for: self.name).serialize(to: &serializer)
+        SQLColumn(self.name, table: SQLIdentifier("excluded")).serialize(to: &serializer)
+    }
+}

--- a/Sources/SQLKit/Query/SQLUpsert.swift
+++ b/Sources/SQLKit/Query/SQLUpsert.swift
@@ -1,0 +1,36 @@
+public struct SQLUpsert: SQLExpression {
+    /// The base `INSERT` statement.
+    public var insert: SQLInsert
+    
+    /// The conflict targets, if any.
+    public var targets: [SQLExpression]?
+    
+    /// The conflict condition, if any.
+    public var condition: SQLExpression?
+    
+    /// The action to be taken upon conflicts.
+    public var action: SQLExpression
+    
+    /// Creates a new `SQLUpsert`.
+    public init(table: SQLExpression) {
+        self.insert = SQLInsert(table: table)
+        self.targets = nil
+        self.condition = nil
+        self.action = SQLConflictAction.nothing
+    }
+    
+    public func serialize(to serializer: inout SQLSerializer) {
+        self.insert.serialize(to: &serializer)
+        serializer.write(" ON CONFLICT")
+        if let targets = self.targets {
+            serializer.write(" ")
+            SQLGroupExpression(targets).serialize(to: &serializer)
+        }
+        if let condition = self.condition {
+            serializer.write(" WHERE ")
+            condition.serialize(to: &serializer)
+        }
+        serializer.write(" ")
+        self.action.serialize(to: &serializer)
+    }
+}


### PR DESCRIPTION
Currently, the emitted syntax is compatible with SQLite and PostgreSQL, but not MySQL. Because MySQL diverges radically from the standard, considerable additional work would be needed to support it. Some design flaws still exist in this implementation, but it is possible to specify all of the common clauses needed for `UPSERT`. There is no support for SQLite's `ON CONFLICT ROLLBACK/ABORT/FAIL/IGNORE/REPLACE` syntax, nor for any of the more esoteric clauses supported by PostgreSQL. It doesn't seem useful to add that support; it's unlikely that a query requiring such specialized facilities would be portable across databases in any event.