### PR TITLE
Update SQLBinaryOperator.swift to include "like" and "notLike"

### DIFF
--- a/Sources/SQLKit/Query/SQLBinaryOperator.swift
+++ b/Sources/SQLKit/Query/SQLBinaryOperator.swift
@@ -74,6 +74,8 @@ public enum SQLBinaryOperator: SQLExpression {
         case .lessThanOrEqual: serializer.write("<=")
         case .is: serializer.write("IS")
         case .isNot: serializer.write("IS NOT")
+        case .like: serializer.write("LIKE")
+        case .notLike: serializer.write("NOT LIKE")
         default:
             print(self)
             fatalError()


### PR DESCRIPTION
Added `like` and `notLike` to the `serialize`

I don't see why they would not be added? It throws me an error without it when trying to express "LIKE" in MySQL. This might not be the only fix needed but I figured they can and should be included anyways.