### PR TITLE
Implement remaining binary operators

### DIFF
--- a/Sources/SQLKit/Query/SQLBinaryOperator.swift
+++ b/Sources/SQLKit/Query/SQLBinaryOperator.swift
@@ -76,9 +76,22 @@ public enum SQLBinaryOperator: SQLExpression {
         case .isNot: serializer.write("IS NOT")
         case .like: serializer.write("LIKE")
         case .notLike: serializer.write("NOT LIKE")
-        default:
-            print(self)
-            fatalError()
+        case .multiply: serializer.write("*")
+        case .divide: serializer.write("/")
+        case .modulo: serializer.write("%")
+        case .add: serializer.write("+")
+        case .subtract: serializer.write("-")
+
+        // See https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_pipes_as_concat
+        case .concatenate:
+            fatalError("""
+                || is not implemented because MySQL doesn't always support it, even though everyone else does.
+                Use `SQLFunction("CONCAT", args...)` for MySQL or `SQLRaw("||")` with Postgres and SQLite.
+                """)
+        
+        // "warning: Default will never be executed".
+        //default:
+        //    fatalError("\(self) operator is not implemented, probably because it needs extra work across SQL dialects.")
         }
     }
 }

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -107,6 +107,24 @@ final class SQLKitTests: XCTestCase {
         // Yes, this query is very much pure gibberish.
         XCTAssertEqual(db.results[0], "SELECT * FROM `planets` OUTER JOIN (SELECT `name` FROM `stars` WHERE `orion` = `please space`) AS `star` ON `moons`.`planet_id` IS NOT %%%%%% WHERE NULL")
     }
+    
+    func testBinaryOperators() throws {
+        let db = TestDatabase()
+        
+        try db
+            .update("planets")
+            .set(SQLIdentifier("moons"),
+                 to: SQLBinaryExpression(
+                    left: SQLIdentifier("moons"),
+                    op: SQLBinaryOperator.add,
+                    right: SQLLiteral.numeric("1")
+                )
+            )
+            .where("best_at_space", .greaterThanOrEqual, "yes")
+            .run().wait()
+        
+        XCTAssertEqual(db.results[0], "UPDATE `planets` SET `moons` = `moons` + 1 WHERE `best_at_space` >= ?")
+    }
 }
 
 // MARK: Table Creation


### PR DESCRIPTION
`SQLBinaryOperator.add`, `.subtract`, `.multiply`, `.divide`, and `.modulo` now work.

Unfortunately, `.concatenate` still does not work, because MySQL (being the odd one out, as usual) does not support it by default. However, we do now provide a much more helpful error message when encountering it.