### PR TITLE
Alter column data type support

### DIFF
--- a/Sources/SQLKit/Builders/SQLAlterTableBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLAlterTableBuilder.swift
@@ -127,6 +127,26 @@ public final class SQLAlterTableBuilder: SQLQueryBuilder {
         ))
     }
 
+    public func update(
+        column: SQLIdentifier,
+        type dataType: SQLDataType
+    ) -> Self {
+        self.modifyColumn(SQLAlterColumnDefinitionType(
+            column: column,
+            dataType: dataType
+        ))
+    }
+
+    public func update(
+        column: SQLExpression,
+        type dataType: SQLExpression
+    ) -> Self {
+        self.modifyColumn(SQLAlterColumnDefinitionType(
+            column: column,
+            dataType: dataType
+        ))
+    }
+
     public func modifyColumn(_ columnDefinition: SQLExpression) -> Self {
         self.alterTable.modifyColumns.append(columnDefinition)
         return self

--- a/Sources/SQLKit/Query/SQLAlterColumnDefinitionType.swift
+++ b/Sources/SQLKit/Query/SQLAlterColumnDefinitionType.swift
@@ -1,0 +1,28 @@
+/// Alters the data type of an existing column.
+///
+///     column [alterColumnDefinitionTypeClause] dataType
+///
+public struct SQLAlterColumnDefinitionType: SQLExpression {
+    public var column: SQLExpression
+    public var dataType: SQLExpression
+
+    public init(column: SQLIdentifier, dataType: SQLDataType) {
+        self.column = column
+        self.dataType = dataType
+    }
+
+    public init(column: SQLExpression, dataType: SQLExpression) {
+        self.column = column
+        self.dataType = dataType
+    }
+
+    public func serialize(to serializer: inout SQLSerializer) {
+        serializer.statement {
+            $0.append(self.column)
+            if let clause = $0.dialect.alterTableSyntax.alterColumnDefinitionTypeKeyword {
+                $0.append(clause)
+            }
+            $0.append(self.dataType)
+        }
+    }
+}

--- a/Sources/SQLKit/Query/SQLAlterTable.swift
+++ b/Sources/SQLKit/Query/SQLAlterTable.swift
@@ -43,28 +43,3 @@ public struct SQLAlterTable: SQLExpression {
         }
     }
 }
-
-public struct SQLAlterColumnDefinitionType: SQLExpression {
-    public var column: SQLExpression
-    public var dataType: SQLExpression
-
-    public init(column: SQLIdentifier, dataType: SQLDataType) {
-        self.column = column
-        self.dataType = dataType
-    }
-
-    public init(column: SQLExpression, dataType: SQLExpression) {
-        self.column = column
-        self.dataType = dataType
-    }
-
-    public func serialize(to serializer: inout SQLSerializer) {
-        serializer.statement {
-            $0.append(self.column)
-            if let clause = $0.dialect.alterTableSyntax.alterColumnDefinitionTypeClause {
-                $0.append(clause)
-            }
-            $0.append(self.dataType)
-        }
-    }
-}

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -12,6 +12,26 @@ public protocol SQLDialect {
     var enumSyntax: SQLEnumSyntax { get }
     var supportsDropBehavior: Bool { get }
     var triggerSyntax: SQLTriggerSyntax { get }
+    var alterTableSyntax: SQLAlterTableSyntax { get }
+}
+
+public struct SQLAlterTableSyntax {
+    public var alterColumnDefinitionClause: SQLExpression?
+    public var alterColumnDefinitionTypeClause: SQLExpression?
+
+    public init(
+        alterColumnDefinitionClause: SQLExpression? = nil,
+        alterColumnDefinitionTypeClause: SQLExpression? = nil
+    ) {
+        self.alterColumnDefinitionClause = alterColumnDefinitionClause
+        self.alterColumnDefinitionTypeClause = alterColumnDefinitionTypeClause
+    }
+}
+
+extension SQLDialect {
+    public var alterTableSyntax: SQLAlterTableSyntax {
+        .init()
+    }
 }
 
 public enum SQLEnumSyntax {

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -15,16 +15,28 @@ public protocol SQLDialect {
     var alterTableSyntax: SQLAlterTableSyntax { get }
 }
 
+/// Controls `ALTER TABLE` syntax.
 public struct SQLAlterTableSyntax {
+    /// Expression for altering a column's definition.
+    ///
+    ///     ALTER TABLE table [alterColumnDefinitionClause] column column_definition
+    ///
+    /// `nil` indicates lack of support for altering existing column definitions.
     public var alterColumnDefinitionClause: SQLExpression?
-    public var alterColumnDefinitionTypeClause: SQLExpression?
+
+    /// Expression for altering a column definition's type.
+    ///
+    ///     ALTER TABLE table [alterColumnDefinitionClause] column [alterColumnDefinitionTypeClause] dataType
+    ///
+    /// `nil` indicates that no extra keyword is required. 
+    public var alterColumnDefinitionTypeKeyword: SQLExpression?
 
     public init(
         alterColumnDefinitionClause: SQLExpression? = nil,
-        alterColumnDefinitionTypeClause: SQLExpression? = nil
+        alterColumnDefinitionTypeKeyword: SQLExpression? = nil
     ) {
         self.alterColumnDefinitionClause = alterColumnDefinitionClause
-        self.alterColumnDefinitionTypeClause = alterColumnDefinitionTypeClause
+        self.alterColumnDefinitionTypeKeyword = alterColumnDefinitionTypeKeyword
     }
 }
 

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -28,7 +28,7 @@ public struct SQLAlterTableSyntax {
     ///
     ///     ALTER TABLE table [alterColumnDefinitionClause] column [alterColumnDefinitionTypeClause] dataType
     ///
-    /// `nil` indicates that no extra keyword is required. 
+    /// `nil` indicates that no extra keyword is required.
     public var alterColumnDefinitionTypeKeyword: SQLExpression?
 
     public init(

--- a/Sources/SQLKit/SQLSerializer.swift
+++ b/Sources/SQLKit/SQLSerializer.swift
@@ -25,7 +25,7 @@ public struct SQLSerializer {
 
 extension SQLSerializer {
     public mutating func statement(_ closure: (inout SQLStatement) -> ()) {
-        var sql = SQLStatement(parts: [])
+        var sql = SQLStatement(parts: [], database: self.database)
         closure(&sql)
         sql.serialize(to: &self)
     }
@@ -33,6 +33,11 @@ extension SQLSerializer {
 
 public struct SQLStatement: SQLExpression {
     public var parts: [SQLExpression]
+    let database: SQLDatabase
+
+    public var dialect: SQLDialect {
+        self.database.dialect
+    }
 
     public mutating func append(_ raw: String) {
         self.append(SQLRaw(raw))


### PR DESCRIPTION
Adds a new `SQLAlterColumnDefinitionType` expression for use in `SQLAlterTable.modifyColumns`. 

This type is supported by a new `SQLDialect.alterTableSyntax` dialect option. 

```swift
db.alter(table: "planets")
    .update(column: "type", dataType: .int)
    .run()
```

The above builder would result in the following queries:

PostgreSQL:

```sql
ALTER TABLE "planets" ALTER COLUMN "type" SET DATA TYPE BIGINT
```

MySQL:

```sql
ALTER TABLE `planets` MODIFY COLUMN "type" BIGINT
```

SQLite:

```sql
ALTER TABLE "planets"
```

Note: SQLite does not support altering existing columns.