### PR TITLE
Fix multi-column update

### DIFF
--- a/Sources/SQLKit/Query/SQLAlterTable.swift
+++ b/Sources/SQLKit/Query/SQLAlterTable.swift
@@ -41,7 +41,7 @@ public struct SQLAlterTable: SQLExpression {
             (verb: SQLRaw("DROP"), definition: column)
         }
 
-        let modifications = serializer.dialect.alterTableSyntax.alterColumnDefinitionClause.map { clause in
+        let modifications = syntax.alterColumnDefinitionClause.map { clause in
             self.modifyColumns.map { column in
                 (verb: clause, definition: column)
             }

--- a/Sources/SQLKit/Query/SQLAlterTable.swift
+++ b/Sources/SQLKit/Query/SQLAlterTable.swift
@@ -41,11 +41,10 @@ public struct SQLAlterTable: SQLExpression {
             (verb: SQLRaw("DROP"), definition: column)
         }
 
-        let modifications = syntax.alterColumnDefinitionClause.map { clause in
-            self.modifyColumns.map { column in
-                (verb: clause, definition: column)
-            }
-        } ?? []
+        let alterColumnDefinitionCaluse = syntax.alterColumnDefinitionClause ?? SQLRaw("MODIFY")
+        let modifications = self.modifyColumns.map { column in
+            (verb: alterColumnDefinitionCaluse, definition: column)
+        }
 
         let alterations = additions + removals + modifications
 

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -31,12 +31,18 @@ public struct SQLAlterTableSyntax {
     /// `nil` indicates that no extra keyword is required.
     public var alterColumnDefinitionTypeKeyword: SQLExpression?
 
+    /// If true, the dialect supports chaining multiple modifications together. If false,
+    /// the dialect requires separate statements for each change.
+    public var allowsBatch: Bool
+
     public init(
         alterColumnDefinitionClause: SQLExpression? = nil,
-        alterColumnDefinitionTypeKeyword: SQLExpression? = nil
+        alterColumnDefinitionTypeKeyword: SQLExpression? = nil,
+        allowsBatch: Bool = true
     ) {
         self.alterColumnDefinitionClause = alterColumnDefinitionClause
         self.alterColumnDefinitionTypeKeyword = alterColumnDefinitionTypeKeyword
+        self.allowsBatch = allowsBatch
     }
 }
 

--- a/Sources/SQLKitBenchmark/SQLBenchmark+Planets.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmark+Planets.swift
@@ -92,7 +92,7 @@ extension SQLBenchmarker {
             // drop, add, and modify columns
             try self.db.alter(table: "planets")
                 .dropColumn("extra_extra")
-                .modifyColumn("extra", type: .text)
+                .update(column: "extra", type: .text)
                 .column("hi", type: .text)
                 .run().wait()
         }

--- a/Sources/SQLKitBenchmark/SQLBenchmark+Planets.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmark+Planets.swift
@@ -77,6 +77,16 @@ extension SQLBenchmarker {
             .from("planets")
             .where("galaxyID", .equal, SQLBind(5))
             .run().wait()
+
+        // add rows for the sake of testing adding rows
+        try self.db.alter(table: "planets")
+            .column("extra", type: .int)
+            .run().wait()
+
+        try self.db.alter(table: "planets")
+            .column("very_extra", type: .bigint)
+            .column("extra_extra", type: .text)
+            .run().wait()
     }
 }
 

--- a/Sources/SQLKitBenchmark/SQLBenchmark+Planets.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmark+Planets.swift
@@ -78,15 +78,24 @@ extension SQLBenchmarker {
             .where("galaxyID", .equal, SQLBind(5))
             .run().wait()
 
-        // add rows for the sake of testing adding rows 
+        // add columns for the sake of testing adding columns
         try self.db.alter(table: "planets")
             .column("extra", type: .int)
             .run().wait()
 
-        try self.db.alter(table: "planets")
-            .column("very_extra", type: .bigint)
-            .column("extra_extra", type: .text)
-            .run().wait()
+        if self.db.dialect.alterTableSyntax.allowsBatch {
+            try self.db.alter(table: "planets")
+                .column("very_extra", type: .bigint)
+                .column("extra_extra", type: .text)
+                .run().wait()
+
+            // drop, add, and modify columns
+            try self.db.alter(table: "planets")
+                .dropColumn("extra_extra")
+                .modifyColumn("extra", type: .text)
+                .column("hi", type: .text)
+                .run().wait()
+        }
     }
 }
 

--- a/Sources/SQLKitBenchmark/SQLBenchmark+Planets.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmark+Planets.swift
@@ -78,7 +78,7 @@ extension SQLBenchmarker {
             .where("galaxyID", .equal, SQLBind(5))
             .run().wait()
 
-        // add rows for the sake of testing adding rows
+        // add rows for the sake of testing adding rows 
         try self.db.alter(table: "planets")
             .column("extra", type: .int)
             .run().wait()

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -146,8 +146,8 @@ final class SQLKitTests: XCTestCase {
         XCTAssertEqual(db.results[4], "ALTER TABLE `alterable` DROP `hello` , DROP `there`")
 
         try db.alter(table: "alterable")
-            .modifyColumn("hello", type: .text)
-            .modifyColumn("there", type: .text)
+            .update(column: "hello", type: .text)
+            .update(column: "there", type: .text)
             .run().wait()
         XCTAssertEqual(db.results[5], "ALTER TABLE `alterable` MODIFY `hello` TEXT , MODIFY `there` TEXT")
 
@@ -155,7 +155,7 @@ final class SQLKitTests: XCTestCase {
         try db.alter(table: "alterable")
             .column("hello", type: .text)
             .dropColumn("there")
-            .modifyColumn("again", type: .text)
+            .update(column: "again", type: .text)
             .run().wait()
         XCTAssertEqual(db.results[6], "ALTER TABLE `alterable` ADD `hello` TEXT , DROP `there` , MODIFY `again` TEXT")
     }

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -112,6 +112,53 @@ final class SQLKitTests: XCTestCase {
         try db.drop(table: "planets").restrict().run().wait()
         XCTAssertEqual(db.results[9], "DROP TABLE `planets` RESTRICT")
     }
+
+    func testAltering() throws {
+        let db = TestDatabase()
+
+        // SINGLE
+        try db.alter(table: "alterable")
+            .column("hello", type: .text)
+            .run().wait()
+        XCTAssertEqual(db.results[0], "ALTER TABLE `alterable` ADD `hello` TEXT")
+
+        try db.alter(table: "alterable")
+            .dropColumn("hello")
+            .run().wait()
+        XCTAssertEqual(db.results[1], "ALTER TABLE `alterable` DROP `hello`")
+
+        try db.alter(table: "alterable")
+            .modifyColumn("hello", type: .text)
+            .run().wait()
+        XCTAssertEqual(db.results[2], "ALTER TABLE `alterable` MODIFY `hello` TEXT")
+
+        // BATCH
+        try db.alter(table: "alterable")
+            .column("hello", type: .text)
+            .column("there", type: .text)
+            .run().wait()
+        XCTAssertEqual(db.results[3], "ALTER TABLE `alterable` ADD `hello` TEXT , ADD `there` TEXT")
+
+        try db.alter(table: "alterable")
+            .dropColumn("hello")
+            .dropColumn("there")
+            .run().wait()
+        XCTAssertEqual(db.results[4], "ALTER TABLE `alterable` DROP `hello` , DROP `there`")
+
+        try db.alter(table: "alterable")
+            .modifyColumn("hello", type: .text)
+            .modifyColumn("there", type: .text)
+            .run().wait()
+        XCTAssertEqual(db.results[5], "ALTER TABLE `alterable` MODIFY `hello` TEXT , MODIFY `there` TEXT")
+
+        // MIXED
+        try db.alter(table: "alterable")
+            .column("hello", type: .text)
+            .dropColumn("there")
+            .modifyColumn("again", type: .text)
+            .run().wait()
+        XCTAssertEqual(db.results[6], "ALTER TABLE `alterable` ADD `hello` TEXT , DROP `there` , MODIFY `again` TEXT")
+    }
     
     func testDistinct() throws {
         let db = TestDatabase()

--- a/Tests/SQLKitTests/Utilities.swift
+++ b/Tests/SQLKitTests/Utilities.swift
@@ -110,6 +110,8 @@ struct GenericDialect: SQLDialect {
 
     var triggerSyntax = SQLTriggerSyntax()
 
+    var alterTableSyntax = SQLAlterTableSyntax(alterColumnDefinitionClause: SQLRaw("MODIFY"), alterColumnDefinitionTypeKeyword: nil)
+
     mutating func setTriggerSyntax(create: SQLTriggerSyntax.Create = [], drop: SQLTriggerSyntax.Drop = []) {
         self.triggerSyntax.create = create
         self.triggerSyntax.drop = drop


### PR DESCRIPTION
Fixes https://github.com/vapor/sql-kit/issues/96

There are two ways to go about this, I suppose. Either split this PR up so that `allowsBatch` can be introduced first and `SQLiteKit` updated to not support it, or just merge this with the broken `SQLiteKit` test (which is only breaking because I added a benchmark test that exercises batch column alterations in this PR anyway) and then follow quickly with a PR that turns `allowsBatch` off for `SQLiteKit`.

I'm partial to the easy route, but no strong opinion.