### PR TITLE
Fix SQLRaw initializer

### DIFF
--- a/Sources/SQLKit/Query/SQLRaw.swift
+++ b/Sources/SQLKit/Query/SQLRaw.swift
@@ -5,7 +5,7 @@ public struct SQLRaw: SQLExpression {
     
     public init(_ sql: String, _ binds: [Encodable] = []) {
         self.sql = sql
-        self.binds = []
+        self.binds = binds
     }
     
     public func serialize(to serializer: inout SQLSerializer) {


### PR DESCRIPTION
`binds` is  now correctly set when using `SQLRaw`'s initializer (#99, fixes #95). 