### PR TITLE
Adds a `normalizeSQLConstraint` method

### DIFF
--- a/Sources/SQLKit/Query/SQLConstraint.swift
+++ b/Sources/SQLKit/Query/SQLConstraint.swift
@@ -34,29 +34,9 @@ extension SQLDialect {
         guard identifier.utf8.count >= self.maximumConstraintIdentifierLength else { return identifier }
         
         var normalizedIdentifier = identifier
-        let midPoint = identifier.count >> 1 // midpoint as extended grapheme cluster count, rounding down
-        let utf8Midpoint = identifier.index(identifier.startIndex, offsetBy: midPoint).samePosition(in: identifier.utf8)!
-        let excessInBytes = identifier.utf8.count - self.maximumConstraintIdentifierLength // number of *bytes* by which the string is too long
-        let excessCutdown = excessInBytes >> 1 // number of bytes on either side of the midpoint to remove
-        var utf8PreCutdownIndex = identifier.utf8.index(utf8Midpoint, offsetBy: -excessCutdown)
-        var realPreCutdownIndex = utf8PreCutdownIndex.samePosition(in: identifier)
-        while realPreCutdownIndex == nil && utf8PreCutdownIndex > identifier.utf8.startIndex {
-            identifier.utf8.formIndex(before: &utf8PreCutdownIndex)
-            realPreCutdownIndex = utf8PreCutdownIndex.samePosition(in: identifier)
+        while normalizedIdentifier.utf8.count >= self.maximumConstraintIdentifierLength && !normalizedIdentifier.isEmpty {
+            normalizedIdentifier.remove(at: normalizedIdentifier.index(normalizedIdentifier.startIndex, offsetBy: normalizedIdentifier.count >> 1))
         }
-        
-        var utf8PostCutdownIndex = identifier.utf8.index(utf8Midpoint, offsetBy: excessCutdown)
-        var realPostCutdownIndex = utf8PostCutdownIndex.samePosition(in: identifier)
-        while realPostCutdownIndex == nil && utf8PostCutdownIndex < identifier.utf8.endIndex {
-            identifier.utf8.formIndex(after: &utf8PostCutdownIndex)
-            realPostCutdownIndex = utf8PostCutdownIndex.samePosition(in: identifier)
-        }
-        
-        let cutdownRange = (realPreCutdownIndex!)...(realPostCutdownIndex!)
-
-        // make sure we didn't accidentally generate something that'll result in an empty string or out-of-bounds crash; this should only be possible if a dialect declares a maximum length of less than 4
-        assert(cutdownRange.lowerBound > identifier.startIndex && cutdownRange.upperBound < identifier.endIndex)
-        normalizedIdentifier.removeSubrange((realPreCutdownIndex!)...(realPostCutdownIndex!))
         
         return normalizedIdentifier
     }

--- a/Sources/SQLKit/Query/SQLConstraint.swift
+++ b/Sources/SQLKit/Query/SQLConstraint.swift
@@ -16,6 +16,7 @@ public struct SQLConstraint: SQLExpression {
 
     public func serialize(to serializer: inout SQLSerializer) {
         if let name = self.name {
+            serializer.write("CONSTRAINT ")
             if let identifier = (name as? SQLIdentifier)?.string {
                 let normalizedName = serializer.dialect.normalizeSQLConstraintIdentifier(identifier)
                 SQLIdentifier(normalizedName).serialize(to: &serializer)

--- a/Sources/SQLKit/Query/SQLConstraint.swift
+++ b/Sources/SQLKit/Query/SQLConstraint.swift
@@ -18,7 +18,7 @@ public struct SQLConstraint: SQLExpression {
         if let name = self.name {
             serializer.write("CONSTRAINT ")
             if let identifier = (name as? SQLIdentifier)?.string {
-                let normalizedName = serializer.dialect.normalizeSQLConstraintIdentifier(identifier)
+                let normalizedName = serializer.dialect.normalizeSQLConstraintIdentifier(identifier: identifier)
                 SQLIdentifier(normalizedName).serialize(to: &serializer)
             } else {
                 name.serialize(to: &serializer)
@@ -26,18 +26,5 @@ public struct SQLConstraint: SQLExpression {
             serializer.write(" ")
         }
         self.algorithm.serialize(to: &serializer)
-    }
-}
-
-extension SQLDialect {
-    public func normalizeSQLConstraintIdentifier(_ identifier: String) -> String {
-        guard identifier.utf8.count >= self.maximumConstraintIdentifierLength else { return identifier }
-        
-        var normalizedIdentifier = identifier
-        while normalizedIdentifier.utf8.count >= self.maximumConstraintIdentifierLength && !normalizedIdentifier.isEmpty {
-            normalizedIdentifier.remove(at: normalizedIdentifier.index(normalizedIdentifier.startIndex, offsetBy: normalizedIdentifier.count >> 1))
-        }
-        
-        return normalizedIdentifier
     }
 }

--- a/Sources/SQLKit/Query/SQLConstraint.swift
+++ b/Sources/SQLKit/Query/SQLConstraint.swift
@@ -16,10 +16,23 @@ public struct SQLConstraint: SQLExpression {
 
     public func serialize(to serializer: inout SQLSerializer) {
         if let name = self.name {
-            serializer.write("CONSTRAINT ")
-            name.serialize(to: &serializer)
+            if let identifier = (name as? SQLIdentifier)?.string {
+                let normalizedName = serializer.dialect.normalizeSQLConstraintIdentifier(identifier)
+                SQLIdentifier(normalizedName).serialize(to: &serializer)
+            } else {
+                name.serialize(to: &serializer)
+            }
             serializer.write(" ")
         }
         self.algorithm.serialize(to: &serializer)
+    }
+}
+
+extension SQLDialect {
+    public func normalizeSQLConstraintIdentifier(_ identifier: String) -> String {
+        guard identifier.utf8.count > self.maximumConstraintIdentifierLength else { return identifier }
+        let midPoint = (identifier.count >> 1) - ((identifier.utf8.count - self.maximumConstraintIdentifierLength) >> 1)
+        let maxPrefixVal = Swift.max(identifier.startIndex, identifier.index(identifier.startIndex, offsetBy: midPoint))
+        return String(identifier.prefix(upTo: maxPrefixVal) + identifier.suffix(midPoint))
     }
 }

--- a/Sources/SQLKit/Query/SQLConstraint.swift
+++ b/Sources/SQLKit/Query/SQLConstraint.swift
@@ -17,12 +17,8 @@ public struct SQLConstraint: SQLExpression {
     public func serialize(to serializer: inout SQLSerializer) {
         if let name = self.name {
             serializer.write("CONSTRAINT ")
-            if let identifier = (name as? SQLIdentifier)?.string {
-                let normalizedName = serializer.dialect.normalizeSQLConstraintIdentifier(identifier: identifier)
-                SQLIdentifier(normalizedName).serialize(to: &serializer)
-            } else {
-                name.serialize(to: &serializer)
-            }
+            let normalizedName = serializer.dialect.normalizeSQLConstraint(identifier: name)
+            normalizedName.serialize(to: &serializer)
             serializer.write(" ")
         }
         self.algorithm.serialize(to: &serializer)

--- a/Sources/SQLKit/Query/SQLConstraint.swift
+++ b/Sources/SQLKit/Query/SQLConstraint.swift
@@ -46,10 +46,10 @@ extension SQLDialect {
         }
         
         var utf8PostCutdownIndex = identifier.utf8.index(utf8Midpoint, offsetBy: excessCutdown)
-        var realPostCutdownIndex = utf8PreCutdownIndex.samePosition(in: identifier)
-        while realPostCutdownIndex == nil && utf8PreCutdownIndex > identifier.utf8.endIndex {
+        var realPostCutdownIndex = utf8PostCutdownIndex.samePosition(in: identifier)
+        while realPostCutdownIndex == nil && utf8PostCutdownIndex < identifier.utf8.endIndex {
             identifier.utf8.formIndex(after: &utf8PostCutdownIndex)
-            realPostCutdownIndex = utf8PreCutdownIndex.samePosition(in: identifier)
+            realPostCutdownIndex = utf8PostCutdownIndex.samePosition(in: identifier)
         }
         
         let cutdownRange = (realPreCutdownIndex!)...(realPostCutdownIndex!)

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -14,7 +14,7 @@ public protocol SQLDialect {
     var triggerSyntax: SQLTriggerSyntax { get }
     var alterTableSyntax: SQLAlterTableSyntax { get }
     func customDataType(for dataType: SQLDataType) -> SQLExpression?
-    var maximumConstraintIdentifierLength: Int { get }
+    func normalizeSQLConstraintIdentifier(identifier: String) -> String
 }
 
 extension SQLDialect {
@@ -139,7 +139,7 @@ extension SQLDialect {
         return SQLTriggerSyntax()
     }
     
-    public var maximumConstraintIdentifierLength: Int {
-        return 64
+    public func normalizeSQLConstraintIdentifier(identifier: String) -> String {
+        return identifier
     }
 }

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -138,4 +138,8 @@ extension SQLDialect {
     public var triggerSyntax: SQLTriggerSyntax {
         return SQLTriggerSyntax()
     }
+    
+    public var maximumConstraintIdentifierLength: Int {
+        return 64
+    }
 }

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -14,7 +14,7 @@ public protocol SQLDialect {
     var triggerSyntax: SQLTriggerSyntax { get }
     var alterTableSyntax: SQLAlterTableSyntax { get }
     func customDataType(for dataType: SQLDataType) -> SQLExpression?
-    func normalizeSQLConstraintIdentifier(identifier: String) -> String
+    func normalizeSQLConstraint(identifier: SQLExpression) -> SQLExpression
 }
 
 extension SQLDialect {
@@ -139,7 +139,7 @@ extension SQLDialect {
         return SQLTriggerSyntax()
     }
     
-    public func normalizeSQLConstraintIdentifier(identifier: String) -> String {
+    public func normalizeSQLConstraint(identifier: SQLExpression) -> SQLExpression {
         return identifier
     }
 }

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -14,6 +14,7 @@ public protocol SQLDialect {
     var triggerSyntax: SQLTriggerSyntax { get }
     var alterTableSyntax: SQLAlterTableSyntax { get }
     func customDataType(for dataType: SQLDataType) -> SQLExpression?
+    var maximumConstraintIdentifierLength: Int { get }
 }
 
 extension SQLDialect {

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -263,10 +263,10 @@ CREATE TABLE `planets`(`id` BIGINT PRIMARY KEY AUTOINCREMENT, `name` TEXT DEFAUL
     func testConstraintLengthNormalization() {
         XCTAssertEqual(
             db.dialect.normalizeSQLConstraintIdentifier("fk:obnoxiously_long_table_name.other_table_name_id+other_table_name.id"),
-            "fk:obnoxiously_long_table_name.oble_name_id+other_table_name.id"
+            "fk:obnoxiously_long_table_name.oher_table_name_id+other_table_name.id"
         )
 
-        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("smileyIdentifier😀IsASmiley"), "smileyIdentifier😀IsASmiley")
+        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("smileyIdentifier😀😀😀😀😀😀😀😀😀😀😀😀IsASmileyIsASmileyIsASmiley"), "smileyIdentifier😀IsASmiley")
         XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("ohWellWhatA🤷🏻‍♀️KindOfDay"), "ohWellWhatA🤷🏻‍♀️KindOfDay")
         XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("checkOutHowĈôm̂b̂în̂în̂ĝT⃠h⃠i⃠n⃠g⃠s⃠Works"),"checkOutHowĈôm̂b̂în̂în̂ĝT⃠h⃠i⃠n⃠g⃠s⃠Works")
     }

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -263,12 +263,12 @@ CREATE TABLE `planets`(`id` BIGINT PRIMARY KEY AUTOINCREMENT, `name` TEXT DEFAUL
     func testConstraintLengthNormalization() {
         XCTAssertEqual(
             db.dialect.normalizeSQLConstraintIdentifier("fk:obnoxiously_long_table_name.other_table_name_id+other_table_name.id"),
-            "fk:obnoxiously_long_table_name.oher_table_name_id+other_table_name.id"
+            "fk:obnoxiously_long_table_name.oble_name_id+other_table_name.id"
         )
 
-        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("smileyIdentifier😀😀😀😀😀😀😀😀😀😀😀😀IsASmileyIsASmileyIsASmiley"), "smileyIdentifier😀IsASmiley")
-        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("ohWellWhatA🤷🏻‍♀️KindOfDay"), "ohWellWhatA🤷🏻‍♀️KindOfDay")
-        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("checkOutHowĈôm̂b̂în̂în̂ĝT⃠h⃠i⃠n⃠g⃠s⃠Works"),"checkOutHowĈôm̂b̂în̂în̂ĝT⃠h⃠i⃠n⃠g⃠s⃠Works")
+        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("smileyIdentifier😀😀😀😀😀😀😀😀😀😀😀😀IsASmileyIsASmileyIsASmiley"), "smileyIdentifier😀😀😀😀😀😀😀sASmileyIsASmiley")
+        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("ohWellWhatA🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️KindOfDayKindOfDayKindOfDay"), "ohWellWhatA🤷🏻‍♀️KindOfDay")
+        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("checkOutHowĈôm̂b̂în̂în̂ĝôm̂b̂în̂în̂ĝôm̂b̂în̂în̂ĝT⃠h⃠i⃠i⃠i⃠n⃠g⃠s⃠WorksWorksWorksWorks"),"checkOutHowĈôm̂b̂în̂în̂ĝT⃠h⃠i⃠n⃠g⃠s⃠Works")
     }
 
     func testMultipleColumnConstraintsPerRow() throws {

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -259,6 +259,13 @@ CREATE TABLE `planets`(`id` BIGINT PRIMARY KEY AUTOINCREMENT, `name` TEXT DEFAUL
 """
                        )
     }
+    
+    func testConstraintLengthNormalization() {
+        XCTAssertEqual(
+            db.dialect.normalizeSQLConstraintIdentifier("fk:obnoxiously_long_table_name.other_table_name_id+other_table_name.id"),
+            "fk:obnoxiously_long_table_name.oable_name_id+other_table_name.id"
+        )
+    }
 
     func testMultipleColumnConstraintsPerRow() throws {
         try db.create(table: "planets")

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -261,14 +261,11 @@ CREATE TABLE `planets`(`id` BIGINT PRIMARY KEY AUTOINCREMENT, `name` TEXT DEFAUL
     }
     
     func testConstraintLengthNormalization() {
+        // Default impl is to leave as-is
         XCTAssertEqual(
-            db.dialect.normalizeSQLConstraintIdentifier("fk:obnoxiously_long_table_name.other_table_name_id+other_table_name.id"),
-            "fk:obnoxiously_long_table_name.oble_name_id+other_table_name.id"
+            db.dialect.normalizeSQLConstraintIdentifier(identifier: "fk:obnoxiously_long_table_name.other_table_name_id+other_table_name.id"),
+            "fk:obnoxiously_long_table_name.other_table_name_id+other_table_name.id"
         )
-
-        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("smileyIdentifier😀😀😀😀😀😀😀😀😀😀😀😀IsASmileyIsASmileyIsASmiley"), "smileyIdentifier😀😀😀😀😀😀ileyIsASmileyIsASmiley")
-        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("ohWellWhatA🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️KindOfDayKindOfDayKindOfDay"), "ohWellWhatA🤷🏻‍♀️🤷🏻‍♀️fDayKindOfDay")
-        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("checkOutHowĈôm̂b̂în̂în̂ĝôm̂b̂în̂în̂ĝôm̂b̂în̂în̂ĝT⃠h⃠i⃠i⃠i⃠n⃠g⃠s⃠WorksWorksWorksWorks"),"checkOutHowĈôm̂b̂în̂în̂ĝôm̂s⃠WorksWorksWorksWorks")
     }
 
     func testMultipleColumnConstraintsPerRow() throws {

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -266,9 +266,9 @@ CREATE TABLE `planets`(`id` BIGINT PRIMARY KEY AUTOINCREMENT, `name` TEXT DEFAUL
             "fk:obnoxiously_long_table_name.oble_name_id+other_table_name.id"
         )
 
-        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("smileyIdentifier😀😀😀😀😀😀😀😀😀😀😀😀IsASmileyIsASmileyIsASmiley"), "smileyIdentifier😀😀😀😀😀😀😀sASmileyIsASmiley")
-        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("ohWellWhatA🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️KindOfDayKindOfDayKindOfDay"), "ohWellWhatA🤷🏻‍♀️KindOfDay")
-        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("checkOutHowĈôm̂b̂în̂în̂ĝôm̂b̂în̂în̂ĝôm̂b̂în̂în̂ĝT⃠h⃠i⃠i⃠i⃠n⃠g⃠s⃠WorksWorksWorksWorks"),"checkOutHowĈôm̂b̂în̂în̂ĝT⃠h⃠i⃠n⃠g⃠s⃠Works")
+        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("smileyIdentifier😀😀😀😀😀😀😀😀😀😀😀😀IsASmileyIsASmileyIsASmiley"), "smileyIdentifier😀😀😀😀😀😀ileyIsASmileyIsASmiley")
+        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("ohWellWhatA🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️🤷🏻‍♀️KindOfDayKindOfDayKindOfDay"), "ohWellWhatA🤷🏻‍♀️🤷🏻‍♀️fDayKindOfDay")
+        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("checkOutHowĈôm̂b̂în̂în̂ĝôm̂b̂în̂în̂ĝôm̂b̂în̂în̂ĝT⃠h⃠i⃠i⃠i⃠n⃠g⃠s⃠WorksWorksWorksWorks"),"checkOutHowĈôm̂b̂în̂în̂ĝôm̂s⃠WorksWorksWorksWorks")
     }
 
     func testMultipleColumnConstraintsPerRow() throws {

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -263,8 +263,12 @@ CREATE TABLE `planets`(`id` BIGINT PRIMARY KEY AUTOINCREMENT, `name` TEXT DEFAUL
     func testConstraintLengthNormalization() {
         XCTAssertEqual(
             db.dialect.normalizeSQLConstraintIdentifier("fk:obnoxiously_long_table_name.other_table_name_id+other_table_name.id"),
-            "fk:obnoxiously_long_table_name.oable_name_id+other_table_name.id"
+            "fk:obnoxiously_long_table_name.oble_name_id+other_table_name.id"
         )
+
+        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("smileyIdentifier😀IsASmiley"), "smileyIdentifier😀IsASmiley")
+        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("ohWellWhatA🤷🏻‍♀️KindOfDay"), "ohWellWhatA🤷🏻‍♀️KindOfDay")
+        XCTAssertEqual(db.dialect.normalizeSQLConstraintIdentifier("checkOutHowĈôm̂b̂în̂în̂ĝT⃠h⃠i⃠n⃠g⃠s⃠Works"),"checkOutHowĈôm̂b̂în̂în̂ĝT⃠h⃠i⃠n⃠g⃠s⃠Works")
     }
 
     func testMultipleColumnConstraintsPerRow() throws {

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -263,8 +263,8 @@ CREATE TABLE `planets`(`id` BIGINT PRIMARY KEY AUTOINCREMENT, `name` TEXT DEFAUL
     func testConstraintLengthNormalization() {
         // Default impl is to leave as-is
         XCTAssertEqual(
-            db.dialect.normalizeSQLConstraintIdentifier(identifier: "fk:obnoxiously_long_table_name.other_table_name_id+other_table_name.id"),
-            "fk:obnoxiously_long_table_name.other_table_name_id+other_table_name.id"
+            (db.dialect.normalizeSQLConstraint(identifier: SQLIdentifier("fk:obnoxiously_long_table_name.other_table_name_id+other_table_name.id")) as! SQLIdentifier).string,
+            SQLIdentifier("fk:obnoxiously_long_table_name.other_table_name_id+other_table_name.id").string
         )
     }
 

--- a/Tests/SQLKitTests/Utilities.swift
+++ b/Tests/SQLKitTests/Utilities.swift
@@ -116,6 +116,4 @@ struct GenericDialect: SQLDialect {
         self.triggerSyntax.create = create
         self.triggerSyntax.drop = drop
     }
-    
-    var maximumConstraintIdentifierLength: Int = 64
 }

--- a/Tests/SQLKitTests/Utilities.swift
+++ b/Tests/SQLKitTests/Utilities.swift
@@ -116,4 +116,6 @@ struct GenericDialect: SQLDialect {
         self.triggerSyntax.create = create
         self.triggerSyntax.drop = drop
     }
+    
+    var maximumConstraintIdentifierLength: Int = 64
 }


### PR DESCRIPTION
Adds a `normalizeSQLConstraint` method to `SQLDialect` so that the drivers can truncate constraint identifiers that are too long. 