### PR TITLE
Remove unnecessary platforms minimum

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,9 +3,6 @@ import PackageDescription
 
 let package = Package(
     name: "sql-kit",
-    platforms: [
-       .macOS(.v10_15)
-    ],
     products: [
         .library(name: "SQLKit", targets: ["SQLKit"]),
         .library(name: "SQLKitBenchmark", targets: ["SQLKitBenchmark"]),


### PR DESCRIPTION
This is not necessary and causes error in SQLiteKit:
The package product 'SQLiteNIO' requires minimum platform version 13.0 for the iOS platform, but this target supports 8.0