### PR TITLE
Allow binding a list of values in SQLQueryString

### DIFF
--- a/Sources/SQLKit/Query/SQLQueryString.swift
+++ b/Sources/SQLKit/Query/SQLQueryString.swift
@@ -2,7 +2,7 @@ public struct SQLQueryString {
     enum Fragment {
         case literal(String)
         case value(Encodable)
-        case list([Encodable])
+        case values([Encodable])
     }
     
     var fragments: [Fragment]
@@ -42,8 +42,10 @@ extension SQLQueryString: StringInterpolationProtocol {
         fragments.append(.value(value))
     }
 
-    mutating public func appendInterpolation(bindList values: [Encodable]) {
-        fragments.append(.list(values))
+    /// Binds multiple values in a comma separated list.
+    /// Commonly used with the `IN` operator.
+    mutating public func appendInterpolation(binds values: [Encodable]) {
+        fragments.append(.values(values))
     }
 }
 
@@ -55,7 +57,7 @@ extension SQLQueryString: SQLExpression {
                 serializer.write(str)
             case let .value(v):
                 serializer.write(bind: v)
-            case let .list(l):
+            case let .values(l):
                 SQLList(l.map { SQLBind($0) }).serialize(to: &serializer)
             }
         }

--- a/Sources/SQLKit/Query/SQLQueryString.swift
+++ b/Sources/SQLKit/Query/SQLQueryString.swift
@@ -2,6 +2,7 @@ public struct SQLQueryString {
     enum Fragment {
         case literal(String)
         case value(Encodable)
+        case list([Encodable])
     }
     
     var fragments: [Fragment]
@@ -40,6 +41,10 @@ extension SQLQueryString: StringInterpolationProtocol {
     mutating public func appendInterpolation(bind value: Encodable) {
         fragments.append(.value(value))
     }
+
+    mutating public func appendInterpolation(bindList values: [Encodable]) {
+        fragments.append(.list(values))
+    }
 }
 
 extension SQLQueryString: SQLExpression {
@@ -50,6 +55,8 @@ extension SQLQueryString: SQLExpression {
                 serializer.write(str)
             case let .value(v):
                 serializer.write(bind: v)
+            case let .list(l):
+                SQLList(l.map { SQLBind($0) }).serialize(to: &serializer)
             }
         }
     }


### PR DESCRIPTION
This addition allows binding a list of values. This is useful for `IN` statements for example `WHERE column_name IN (value1, value2, ...)`.

### Usage
```swift
let ids = [1, 2, 3...]

raw("...WHERE IN (\(bindList: ids))")
```