### PR TITLE
Improve `SQLDropIndex`, add `SQLDropIndexBuilder`

### DIFF
--- a/Sources/SQLKit/Builders/SQLDropIndexBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLDropIndexBuilder.swift
@@ -1,0 +1,72 @@
+/// Builds `SQLDropIndex` queries.
+///
+///     db.drop(index: "planet_name_unique").run()
+///
+/// See `SQLDropIndex`.
+public final class SQLDropIndexBuilder: SQLQueryBuilder {
+    /// `DropIndex` query being built.
+    public var dropIndex: SQLDropIndex
+    
+    /// See `SQLQueryBuilder`.
+    public var database: SQLDatabase
+    
+    /// See `SQLQueryBuilder`.
+    public var query: SQLExpression {
+        return self.dropIndex
+    }
+    
+    /// Creates a new `SQLDropIndexBuilder`.
+    public init(_ dropIndex: SQLDropIndex, on database: SQLDatabase) {
+        self.dropIndex = dropIndex
+        self.database = database
+    }
+
+    /// The optional `IF EXISTS` clause suppresses the error that would normally
+    /// result if the index does not exist.
+    public func ifExists() -> Self {
+        dropIndex.ifExists = true
+        return self
+    }
+
+    /// The drop behavior clause specifies if objects that depend on a index
+    /// should also be dropped or not when the index is dropped, for databases
+    /// that support this.
+    public func behavior(_ behavior: SQLDropBehavior) -> Self {
+        dropIndex.behavior = behavior
+        return self
+    }
+
+    /// Adds a `CASCADE` clause to the `DROP INDEX` statement instructing that
+    /// objects that depend on this index should also be dropped.
+    public func cascade() -> Self {
+        dropIndex.behavior = SQLDropBehavior.cascade
+        return self
+    }
+
+    /// Adds a `RESTRICT` clause to the `DROP INDEX` statement instructing that
+    /// if any objects depend on this index, the drop should be refused.
+    public func restrict() -> Self {
+        dropIndex.behavior = SQLDropBehavior.restrict
+        return self
+    }
+}
+
+// MARK: Connection
+
+extension SQLDatabase {
+    /// Creates a new `SQLDropIndexBuilder`.
+    ///
+    ///     db.drop(index: "foo").run()
+    ///
+    public func drop(index name: String) -> SQLDropIndexBuilder {
+        return self.drop(index: SQLIdentifier(name))
+    }
+    
+    /// Creates a new `SQLDropIndexBuilder`.
+    ///
+    ///     db.drop(index: "foo").run()
+    ///
+    public func drop(index name: SQLExpression) -> SQLDropIndexBuilder {
+        return .init(.init(name: name), on: self)
+    }
+}

--- a/Sources/SQLKit/Builders/SQLDropTableBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLDropTableBuilder.swift
@@ -30,21 +30,21 @@ public final class SQLDropTableBuilder: SQLQueryBuilder {
 
     /// The drop behavior clause specifies if objects that depend on a table
     /// should also be dropped or not when the table is dropped, for databases
-    /// that supports this.
+    /// that support this.
     public func behavior(_ behavior: SQLDropBehavior) -> Self {
         dropTable.behavior = behavior
         return self
     }
 
     /// Adds a `CASCADE` clause to the `DROP TABLE` statement instructing that
-    /// objects that depends on this table should also be dropped.
+    /// objects that depend on this table should also be dropped.
     public func cascade() -> Self {
         dropTable.behavior = SQLDropBehavior.cascade
         return self
     }
 
     /// Adds a `RESTRICT` clause to the `DROP TABLE` statement instructing that
-    /// if any objects depends on this table, the drop should be refused.
+    /// if any objects depend on this table, the drop should be refused.
     public func restrict() -> Self {
         dropTable.behavior = SQLDropBehavior.restrict
         return self

--- a/Sources/SQLKit/Query/SQLDropIndex.swift
+++ b/Sources/SQLKit/Query/SQLDropIndex.swift
@@ -1,12 +1,43 @@
+/// `DROP INDEX` query.
+///
+/// See `SQLDropIndexBuilder`.
 public struct SQLDropIndex: SQLExpression {
+    /// Index to drop.
     public var name: SQLExpression
     
+    /// The optional `IF EXISTS` clause suppresses the error that would normally
+    /// result if the index does not exist.
+    public var ifExists: Bool
+
+    /// The optional drop behavior clause specifies if objects that depend on the
+    /// index should also be dropped or not, for databases that support this
+    /// (either `CASCADE` or `RESTRICT`).
+    public var behavior: SQLExpression?
+
+    /// Creates a new `SQLDropIndex`.
     public init(name: SQLExpression) {
         self.name = name
+        self.ifExists = false
     }
     
+    /// See `SQLExpression`.
     public func serialize(to serializer: inout SQLSerializer) {
         serializer.write("DROP INDEX ")
+        if self.ifExists {
+            if serializer.dialect.supportsIfExists {
+                serializer.write("IF EXISTS ")
+            } else {
+                serializer.database.logger.warning("\(serializer.dialect.name) does not support IF EXISTS")
+            }
+        }
         self.name.serialize(to: &serializer)
+        if serializer.dialect.supportsDropBehavior {
+            serializer.write(" ")
+            if let dropBehavior = behavior {
+                dropBehavior.serialize(to: &serializer)
+            } else {
+                SQLDropBehavior.restrict.serialize(to: &serializer)
+            }
+        }
     }
 }

--- a/Sources/SQLKit/Query/SQLDropTable.swift
+++ b/Sources/SQLKit/Query/SQLDropTable.swift
@@ -10,7 +10,7 @@ public struct SQLDropTable: SQLExpression {
     public var ifExists: Bool
 
     /// The optional drop behavior clause specifies if objects that depend on the
-    /// table should also be dropped or not, for databases that supports this
+    /// table should also be dropped or not, for databases that support this
     /// (either `CASCADE` or `RESTRICT`).
     public var behavior: SQLExpression?
 

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -96,9 +96,16 @@ final class SQLKitTests: XCTestCase {
         try db.drop(table: "planets").ifExists().run().wait()
         XCTAssertEqual(db.results[0], "DROP TABLE IF EXISTS `planets`")
 
+        try db.drop(index: "planets_name_idx").ifExists().run().wait()
+        XCTAssertEqual(db.results[1], "DROP INDEX IF EXISTS `planets_name_idx`")
+
         db._dialect.supportsIfExists = false
+        
         try db.drop(table: "planets").ifExists().run().wait()
-        XCTAssertEqual(db.results[1], "DROP TABLE `planets`")
+        XCTAssertEqual(db.results[2], "DROP TABLE `planets`")
+
+        try db.drop(index: "planets_name_idx").ifExists().run().wait()
+        XCTAssertEqual(db.results[3], "DROP INDEX `planets_name_idx`")
     }
 
     func testDropBehavior() throws {
@@ -107,33 +114,64 @@ final class SQLKitTests: XCTestCase {
         try db.drop(table: "planets").run().wait()
         XCTAssertEqual(db.results[0], "DROP TABLE `planets`")
 
-        try db.drop(table: "planets").behavior(.cascade).run().wait()
-        XCTAssertEqual(db.results[1], "DROP TABLE `planets`")
+        try db.drop(index: "planets_name_idx").run().wait()
+        XCTAssertEqual(db.results[1], "DROP INDEX `planets_name_idx`")
 
-        try db.drop(table: "planets").behavior(.restrict).run().wait()
+        try db.drop(table: "planets").behavior(.cascade).run().wait()
         XCTAssertEqual(db.results[2], "DROP TABLE `planets`")
 
-        try db.drop(table: "planets").cascade().run().wait()
-        XCTAssertEqual(db.results[3], "DROP TABLE `planets`")
-
-        try db.drop(table: "planets").restrict().run().wait()
-        XCTAssertEqual(db.results[4], "DROP TABLE `planets`")
-
-        db._dialect.supportsDropBehavior = true
-        try db.drop(table: "planets").run().wait()
-        XCTAssertEqual(db.results[5], "DROP TABLE `planets` RESTRICT")
-
-        try db.drop(table: "planets").behavior(.cascade).run().wait()
-        XCTAssertEqual(db.results[6], "DROP TABLE `planets` CASCADE")
+        try db.drop(index: "planets_name_idx").behavior(.cascade).run().wait()
+        XCTAssertEqual(db.results[3], "DROP INDEX `planets_name_idx`")
 
         try db.drop(table: "planets").behavior(.restrict).run().wait()
-        XCTAssertEqual(db.results[7], "DROP TABLE `planets` RESTRICT")
+        XCTAssertEqual(db.results[4], "DROP TABLE `planets`")
+
+        try db.drop(index: "planets_name_idx").behavior(.restrict).run().wait()
+        XCTAssertEqual(db.results[5], "DROP INDEX `planets_name_idx`")
 
         try db.drop(table: "planets").cascade().run().wait()
-        XCTAssertEqual(db.results[8], "DROP TABLE `planets` CASCADE")
+        XCTAssertEqual(db.results[6], "DROP TABLE `planets`")
+
+        try db.drop(index: "planets_name_idx").cascade().run().wait()
+        XCTAssertEqual(db.results[7], "DROP INDEX `planets_name_idx`")
 
         try db.drop(table: "planets").restrict().run().wait()
-        XCTAssertEqual(db.results[9], "DROP TABLE `planets` RESTRICT")
+        XCTAssertEqual(db.results[8], "DROP TABLE `planets`")
+
+        try db.drop(index: "planets_name_idx").restrict().run().wait()
+        XCTAssertEqual(db.results[9], "DROP INDEX `planets_name_idx`")
+
+        db._dialect.supportsDropBehavior = true
+        
+        try db.drop(table: "planets").run().wait()
+        XCTAssertEqual(db.results[10], "DROP TABLE `planets` RESTRICT")
+
+        try db.drop(index: "planets_name_idx").run().wait()
+        XCTAssertEqual(db.results[11], "DROP INDEX `planets_name_idx` RESTRICT")
+
+        try db.drop(table: "planets").behavior(.cascade).run().wait()
+        XCTAssertEqual(db.results[12], "DROP TABLE `planets` CASCADE")
+
+        try db.drop(index: "planets_name_idx").behavior(.cascade).run().wait()
+        XCTAssertEqual(db.results[13], "DROP INDEX `planets_name_idx` CASCADE")
+
+        try db.drop(table: "planets").behavior(.restrict).run().wait()
+        XCTAssertEqual(db.results[14], "DROP TABLE `planets` RESTRICT")
+
+        try db.drop(index: "planets_name_idx").behavior(.restrict).run().wait()
+        XCTAssertEqual(db.results[15], "DROP INDEX `planets_name_idx` RESTRICT")
+
+        try db.drop(table: "planets").cascade().run().wait()
+        XCTAssertEqual(db.results[16], "DROP TABLE `planets` CASCADE")
+
+        try db.drop(index: "planets_name_idx").cascade().run().wait()
+        XCTAssertEqual(db.results[17], "DROP INDEX `planets_name_idx` CASCADE")
+
+        try db.drop(table: "planets").restrict().run().wait()
+        XCTAssertEqual(db.results[18], "DROP TABLE `planets` RESTRICT")
+
+        try db.drop(index: "planets_name_idx").restrict().run().wait()
+        XCTAssertEqual(db.results[19], "DROP INDEX `planets_name_idx` RESTRICT")
     }
 
     func testAltering() throws {


### PR DESCRIPTION
- `SQLDropIndex` now supports `IF EXISTS` if the underlying database dialect does.

- `SQLDropIndex` now supports `SQLDropBehavior` (`CASCADE` and `RESTRICT`) if the underlying database dialect does.

- Added `SQLDropIndexBuilder` for convenient creation and execution of `SQLDropIndex` queries.

- Fix minor grammar typos in some comments.