### PR TITLE
Add support for RETURNING clause

### DIFF
--- a/Sources/SQLKit/Builders/SQLDeleteBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLDeleteBuilder.swift
@@ -4,7 +4,7 @@
 ///         .where(\.name != "Earth").run()
 ///
 /// See `SQLQueryBuilder` and `SQLPredicateBuilder` for more information.
-public final class SQLDeleteBuilder: SQLQueryBuilder, SQLPredicateBuilder {
+public final class SQLDeleteBuilder: SQLQueryBuilder, SQLPredicateBuilder, SQLReturningBuilder {
     /// `Delete` query being built.
     public var delete: SQLDelete
 
@@ -17,6 +17,11 @@ public final class SQLDeleteBuilder: SQLQueryBuilder, SQLPredicateBuilder {
     public var predicate: SQLExpression? {
         get { return self.delete.predicate }
         set { self.delete.predicate = newValue }
+    }
+
+    public var returning: SQLReturning? {
+        get { return self.delete.returning }
+        set { self.delete.returning = newValue }
     }
     
     /// Creates a new `SQLDeleteBuilder`.

--- a/Sources/SQLKit/Builders/SQLInsertBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLInsertBuilder.swift
@@ -4,7 +4,7 @@
 ///         .value(earth).run()
 ///
 /// See `SQLQueryBuilder` for more information.
-public final class SQLInsertBuilder: SQLQueryBuilder {
+public final class SQLInsertBuilder: SQLQueryBuilder, SQLReturningBuilder {
     /// `Insert` query being built.
     public var insert: SQLInsert
     
@@ -14,6 +14,11 @@ public final class SQLInsertBuilder: SQLQueryBuilder {
     /// See `SQLQueryBuilder`.
     public var query: SQLExpression {
         return self.insert
+    }
+
+    public var returning: SQLReturning? {
+        get { return self.insert.returning }
+        set { self.insert.returning = newValue }
     }
     
     /// Creates a new `SQLInsertBuilder`.

--- a/Sources/SQLKit/Builders/SQLReturningBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLReturningBuilder.swift
@@ -1,0 +1,40 @@
+public protocol SQLReturningBuilder: SQLQueryBuilder {
+    var returning: SQLReturning? { get set }
+}
+
+extension SQLReturningBuilder {
+    /// Specify a column to be returned from the query. The column is a
+    /// string assumed to be a valid SQL identifier and is not qualified.
+    /// The string "*" (a single asterisk) is recognized and replaced by
+    /// `SQLLiteral.all`.
+    ///
+    /// - Parameter column: The name of the column to return, or "*" for all.
+    public func returning(_ column: String) -> Self {
+        if column == "*" {
+            self.returning = .init(SQLColumn(SQLLiteral.all))
+        } else {
+            self.returning = .init(SQLColumn(column))
+        }
+        return self
+    }
+
+    /// Specify a list of columns to be returned as the result of the query.
+    /// Each input is an arbitrary expression.
+    ///
+    /// - Parameter columns: A list of expressions identifying the desired data
+    ///                      to return.
+    public func returning(_ columns: SQLExpression...) -> Self {
+        self.returning = .init(columns)
+        return self
+    }
+
+    /// Specify a list of columns to be returned as the result of the query.
+    /// Each input is an arbitrary expression.
+    ///
+    /// - Parameter columns: A list of expressions identifying the desired data
+    ///                      to return.
+    public func returning(_ columns: [SQLExpression]) -> Self {
+        self.returning = .init(columns)
+        return self
+    }
+}

--- a/Sources/SQLKit/Builders/SQLReturningBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLReturningBuilder.swift
@@ -3,26 +3,32 @@ public protocol SQLReturningBuilder: SQLQueryBuilder {
 }
 
 extension SQLReturningBuilder {
-    /// Specify a column to be returned from the query. The column is a
-    /// string assumed to be a valid SQL identifier and is not qualified.
-    /// The string "*" (a single asterisk) is recognized and replaced by
-    /// `SQLLiteral.all`.
+    /// Specify a list of columns to be part of the result set of the query.
+    /// Each provided name is a string assumed to be a valid SQL identifier and
+    /// is not qualified.
     ///
-    /// - Parameter column: The name of the column to return, or "*" for all.
-    public func returning(_ column: String) -> Self {
-        if column == "*" {
-            self.returning = .init(SQLColumn(SQLLiteral.all))
-        } else {
-            self.returning = .init(SQLColumn(column))
+    /// - parameters:
+    ///     - columns: The names of the columns to return.
+    /// - returns: Self for chaining.
+    public func returning(_ columns: String...) -> Self {
+        let sqlColumns = columns.map { (column) -> SQLColumn in
+            if column == "*" {
+                return SQLColumn(SQLLiteral.all)
+            } else {
+                return SQLColumn(column)
+            }
         }
+
+        self.returning = .init(sqlColumns)
         return self
     }
 
     /// Specify a list of columns to be returned as the result of the query.
     /// Each input is an arbitrary expression.
     ///
-    /// - Parameter columns: A list of expressions identifying the desired data
-    ///                      to return.
+    /// - parameters:
+    ///     - columns: A list of expressions identifying the columns to return.
+    /// - returns: Self for chaining.
     public func returning(_ columns: SQLExpression...) -> Self {
         self.returning = .init(columns)
         return self
@@ -31,8 +37,9 @@ extension SQLReturningBuilder {
     /// Specify a list of columns to be returned as the result of the query.
     /// Each input is an arbitrary expression.
     ///
-    /// - Parameter columns: A list of expressions identifying the desired data
-    ///                      to return.
+    /// - parameters:
+    ///     - column: An array of expressions identifying the columns to return.
+    /// - returns: Self for chaining.
     public func returning(_ columns: [SQLExpression]) -> Self {
         self.returning = .init(columns)
         return self

--- a/Sources/SQLKit/Builders/SQLUpdateBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLUpdateBuilder.swift
@@ -6,7 +6,7 @@
 ///         .run()
 ///
 /// See `SQLQueryBuilder` and `SQLPredicateBuilder` for more information.
-public final class SQLUpdateBuilder: SQLQueryBuilder, SQLPredicateBuilder {
+public final class SQLUpdateBuilder: SQLQueryBuilder, SQLPredicateBuilder, SQLReturningBuilder {
     /// `Update` query being built.
     public var update: SQLUpdate
     
@@ -19,6 +19,11 @@ public final class SQLUpdateBuilder: SQLQueryBuilder, SQLPredicateBuilder {
     public var predicate: SQLExpression? {
         get { return self.update.predicate }
         set { self.update.predicate = newValue }
+    }
+
+    public var returning: SQLReturning? {
+        get { return self.update.returning }
+        set { self.update.returning = newValue }
     }
     
     /// Creates a new `SQLDeleteBuilder`.

--- a/Sources/SQLKit/Query/SQLDelete.swift
+++ b/Sources/SQLKit/Query/SQLDelete.swift
@@ -10,6 +10,7 @@ public struct SQLDelete: SQLExpression {
     /// the expression is false or NULL are retained.
     public var predicate: SQLExpression?
 
+    /// Optionally append a `RETURNING` clause that, where supported, returns the supplied supplied columns.
     public var returning: SQLReturning?
     
     /// Creates a new `SQLDelete`.
@@ -18,12 +19,16 @@ public struct SQLDelete: SQLExpression {
     }
     
     public func serialize(to serializer: inout SQLSerializer) {
-        serializer.write("DELETE FROM ")
-        self.table.serialize(to: &serializer)
-        if let predicate = self.predicate {
-            serializer.write(" WHERE ")
-            predicate.serialize(to: &serializer)
+        serializer.statement {
+            $0.append("DELETE FROM")
+            $0.append(self.table)
+            if let predicate = self.predicate {
+                $0.append("WHERE")
+                $0.append(predicate)
+            }
+            if let returning = self.returning {
+                $0.append(returning)
+            }
         }
-        returning?.serialize(to: &serializer)
     }
 }

--- a/Sources/SQLKit/Query/SQLDelete.swift
+++ b/Sources/SQLKit/Query/SQLDelete.swift
@@ -9,6 +9,8 @@ public struct SQLDelete: SQLExpression {
     /// then only those rows for which the WHERE clause boolean expression is true are deleted. Rows for which
     /// the expression is false or NULL are retained.
     public var predicate: SQLExpression?
+
+    public var returning: SQLReturning?
     
     /// Creates a new `SQLDelete`.
     public init(table: SQLExpression) {
@@ -22,5 +24,6 @@ public struct SQLDelete: SQLExpression {
             serializer.write(" WHERE ")
             predicate.serialize(to: &serializer)
         }
+        returning?.serialize(to: &serializer)
     }
 }

--- a/Sources/SQLKit/Query/SQLInsert.swift
+++ b/Sources/SQLKit/Query/SQLInsert.swift
@@ -13,6 +13,7 @@ public struct SQLInsert: SQLExpression {
     /// Use the `DEFAULT` literal to omit a value and that is specified as a column.
     public var values: [[SQLExpression]]
 
+    /// Optionally append a `RETURNING` clause that, where supported, returns the supplied supplied columns.
     public var returning: SQLReturning?
     
     /// Creates a new `SQLInsert`.
@@ -23,12 +24,15 @@ public struct SQLInsert: SQLExpression {
     }
     
     public func serialize(to serializer: inout SQLSerializer) {
-        serializer.write("INSERT INTO ")
-        self.table.serialize(to: &serializer)
-        serializer.write(" ")
-        SQLGroupExpression(self.columns).serialize(to: &serializer)
-        serializer.write(" VALUES ")
-        SQLList(self.values.map(SQLGroupExpression.init)).serialize(to: &serializer)
-        returning?.serialize(to: &serializer)
+        serializer.statement {
+            $0.append("INSERT INTO")
+            $0.append(self.table)
+            $0.append(SQLGroupExpression(self.columns))
+            $0.append("VALUES")
+            $0.append(SQLList(self.values.map(SQLGroupExpression.init)))
+            if let returning = self.returning {
+                $0.append(returning)
+            }
+        }
     }
 }

--- a/Sources/SQLKit/Query/SQLInsert.swift
+++ b/Sources/SQLKit/Query/SQLInsert.swift
@@ -12,6 +12,8 @@ public struct SQLInsert: SQLExpression {
     ///
     /// Use the `DEFAULT` literal to omit a value and that is specified as a column.
     public var values: [[SQLExpression]]
+
+    public var returning: SQLReturning?
     
     /// Creates a new `SQLInsert`.
     public init(table: SQLExpression) {
@@ -27,5 +29,6 @@ public struct SQLInsert: SQLExpression {
         SQLGroupExpression(self.columns).serialize(to: &serializer)
         serializer.write(" VALUES ")
         SQLList(self.values.map(SQLGroupExpression.init)).serialize(to: &serializer)
+        returning?.serialize(to: &serializer)
     }
 }

--- a/Sources/SQLKit/Query/SQLReturning.swift
+++ b/Sources/SQLKit/Query/SQLReturning.swift
@@ -1,0 +1,16 @@
+/// `RETURNING ...` statement.
+///
+public enum SQLReturning: SQLExpression {
+    case all
+    case fields([SQLIdentifier])
+
+    public func serialize(to serializer: inout SQLSerializer) {
+        serializer.write(" RETURNING ")
+        switch self {
+        case .all:
+            SQLLiteral.all.serialize(to: &serializer)
+        case let .fields(fields):
+            SQLList(fields).serialize(to: &serializer)
+        }
+    }
+}

--- a/Sources/SQLKit/Query/SQLReturning.swift
+++ b/Sources/SQLKit/Query/SQLReturning.swift
@@ -1,16 +1,14 @@
 /// `RETURNING ...` statement.
 ///
-public enum SQLReturning: SQLExpression {
-    case all
-    case fields([SQLIdentifier])
+public struct SQLReturning: SQLExpression {
+    public var columns: [SQLExpression]
+
+    public init(_ columns: [SQLExpression]) {
+        self.columns = columns
+    }
 
     public func serialize(to serializer: inout SQLSerializer) {
         serializer.write(" RETURNING ")
-        switch self {
-        case .all:
-            SQLLiteral.all.serialize(to: &serializer)
-        case let .fields(fields):
-            SQLList(fields).serialize(to: &serializer)
-        }
+        SQLList(columns).serialize(to: &serializer)
     }
 }

--- a/Sources/SQLKit/Query/SQLReturning.swift
+++ b/Sources/SQLKit/Query/SQLReturning.swift
@@ -3,12 +3,20 @@
 public struct SQLReturning: SQLExpression {
     public var columns: [SQLExpression]
 
+    /// Creates a new `SQLReturning`.
+    public init(_ column: SQLColumn) {
+        self.columns = [column]
+    }
+
+    /// Creates a new `SQLReturning`.
     public init(_ columns: [SQLExpression]) {
         self.columns = columns
     }
 
     public func serialize(to serializer: inout SQLSerializer) {
-        serializer.write(" RETURNING ")
-        SQLList(columns).serialize(to: &serializer)
+        serializer.statement {
+            $0.append("RETURNING")
+            $0.append(SQLList(columns))
+        }
     }
 }

--- a/Sources/SQLKit/Query/SQLReturning.swift
+++ b/Sources/SQLKit/Query/SQLReturning.swift
@@ -14,6 +14,11 @@ public struct SQLReturning: SQLExpression {
     }
 
     public func serialize(to serializer: inout SQLSerializer) {
+        guard serializer.dialect.supportsReturning else {
+            serializer.database.logger.warning("\(serializer.dialect.name) does not support 'RETURNING' clause, skipping.")
+            return
+        }
+
         serializer.statement {
             $0.append("RETURNING")
             $0.append(SQLList(columns))

--- a/Sources/SQLKit/Query/SQLReturning.swift
+++ b/Sources/SQLKit/Query/SQLReturning.swift
@@ -19,6 +19,8 @@ public struct SQLReturning: SQLExpression {
             return
         }
 
+        guard !columns.isEmpty else { return }
+
         serializer.statement {
             $0.append("RETURNING")
             $0.append(SQLList(columns))

--- a/Sources/SQLKit/Query/SQLUpdate.swift
+++ b/Sources/SQLKit/Query/SQLUpdate.swift
@@ -18,7 +18,6 @@ public struct SQLUpdate: SQLExpression {
         self.table = table
         self.values = []
         self.predicate = nil
-        self.returning = nil
     }
     
     public func serialize(to serializer: inout SQLSerializer) {

--- a/Sources/SQLKit/Query/SQLUpdate.swift
+++ b/Sources/SQLKit/Query/SQLUpdate.swift
@@ -10,12 +10,15 @@ public struct SQLUpdate: SQLExpression {
     
     /// Optional predicate to limit updated rows.
     public var predicate: SQLExpression?
+
+    public var returning: SQLReturning?
     
     /// Creates a new `SQLUpdate`.
     public init(table: SQLExpression) {
         self.table = table
         self.values = []
         self.predicate = nil
+        self.returning = nil
     }
     
     public func serialize(to serializer: inout SQLSerializer) {
@@ -27,5 +30,6 @@ public struct SQLUpdate: SQLExpression {
             serializer.write(" WHERE ")
             predicate.serialize(to: &serializer)
         }
+        returning?.serialize(to: &serializer)
     }
 }

--- a/Sources/SQLKit/Query/SQLUpdate.swift
+++ b/Sources/SQLKit/Query/SQLUpdate.swift
@@ -11,6 +11,7 @@ public struct SQLUpdate: SQLExpression {
     /// Optional predicate to limit updated rows.
     public var predicate: SQLExpression?
 
+    /// Optionally append a `RETURNING` clause that, where supported, returns the supplied supplied columns.
     public var returning: SQLReturning?
     
     /// Creates a new `SQLUpdate`.
@@ -21,14 +22,18 @@ public struct SQLUpdate: SQLExpression {
     }
     
     public func serialize(to serializer: inout SQLSerializer) {
-        serializer.write("UPDATE ")
-        self.table.serialize(to: &serializer)
-        serializer.write(" SET ")
-        SQLList(self.values).serialize(to: &serializer)
-        if let predicate = self.predicate {
-            serializer.write(" WHERE ")
-            predicate.serialize(to: &serializer)
+        serializer.statement {
+            $0.append("UPDATE")
+            $0.append(self.table)
+            $0.append("SET")
+            $0.append(SQLList(self.values))
+            if let predicate = self.predicate {
+                $0.append("WHERE")
+                $0.append(predicate)
+            }
+            if let returning = self.returning {
+                $0.append(returning)
+            }
         }
-        returning?.serialize(to: &serializer)
     }
 }

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -11,6 +11,7 @@ public protocol SQLDialect {
     var autoIncrementFunction: SQLExpression? { get }
     var enumSyntax: SQLEnumSyntax { get }
     var supportsDropBehavior: Bool { get }
+    var supportsReturning: Bool { get }
     var triggerSyntax: SQLTriggerSyntax { get }
     var alterTableSyntax: SQLAlterTableSyntax { get }
     func customDataType(for dataType: SQLDataType) -> SQLExpression?
@@ -132,6 +133,10 @@ extension SQLDialect {
     }
 
     public var supportsDropBehavior: Bool {
+        return false
+    }
+
+    public var supportsReturning: Bool {
         return false
     }
 

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -266,9 +266,9 @@ final class SQLKitTests: XCTestCase {
         try db.insert(into: "planets")
             .columns("name")
             .values("Jupiter")
-            .returning("name")
+            .returning("id", "name")
             .run().wait()
-        XCTAssertEqual(db.results[0], "INSERT INTO `planets` (`name`) VALUES (?) RETURNING `name`")
+        XCTAssertEqual(db.results[0], "INSERT INTO `planets` (`name`) VALUES (?) RETURNING `id`, `name`")
 
         try db.update("planets")
             .set("name", to: "Jupiter")

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -259,6 +259,28 @@ final class SQLKitTests: XCTestCase {
         
         XCTAssertEqual(db.results[0], "UPDATE `planets` SET `moons` = `moons` + 1 WHERE `best_at_space` >= ?")
     }
+
+    func testReturning() throws {
+        let db = TestDatabase()
+
+        try db.insert(into: "planets")
+            .columns("name")
+            .values("Jupiter")
+            .returning("name")
+            .run().wait()
+        XCTAssertEqual(db.results[0], "INSERT INTO `planets` (`name`) VALUES (?) RETURNING `name`")
+
+        try db.update("planets")
+            .set("name", to: "Jupiter")
+            .returning(SQLColumn("name", table: "planets"))
+            .run().wait()
+        XCTAssertEqual(db.results[1], "UPDATE `planets` SET `name` = ? RETURNING `planets`.`name`")
+
+        try db.delete(from: "planets")
+            .returning("*")
+            .run().wait()
+        XCTAssertEqual(db.results[2], "DELETE FROM `planets` RETURNING *")
+    }
 }
 
 // MARK: Table Creation

--- a/Tests/SQLKitTests/Utilities.swift
+++ b/Tests/SQLKitTests/Utilities.swift
@@ -79,6 +79,8 @@ struct GenericDialect: SQLDialect {
     
     var supportsIfExists: Bool = true
 
+    var supportsReturning: Bool = true
+
     var identifierQuote: SQLExpression {
         return SQLRaw("`")
     }


### PR DESCRIPTION
Adds support for SQL `RETURNING` clauses on supported databases (#110). 

- Adds new `SQLReturning` expression to support returning columns on insert / update / delete queries.

```swift
var select = SQLSelect(...)
select.returning = ...
```

- Adds `SQLReturningBuilder` for use of `SQLReturning` in query builders.

```swift
db.delete()
  .from("planets")
  .returning("*")
  .all()
```

The `returning` method supports multiple columns or identifiers.

```swift
builder.returning("id", "name")
```` 

It also supports qualified names using `SQLColumn`.

```swift
builder.returning(SQLColumn("name", table: "planets"))
```

- Adds new `SQLDialect` option for checking if the current database supports returning. 

```swift
if database.dialect.supportsReturning {
    builder.returning("*")
} else {
    // Fallback.
}
```