### PR TITLE
Add ways to construct SQLQueryString

### DIFF
--- a/Sources/SQLKit/Query/SQLQueryString.swift
+++ b/Sources/SQLKit/Query/SQLQueryString.swift
@@ -71,3 +71,9 @@ extension SQLQueryString: SQLExpression {
         }
     }
 }
+
+extension SQLQueryString {
+    public static func +(lhs: SQLQueryString, rhs: SQLQueryString) -> SQLQueryString {
+        self.init(fragments: lhs.fragments + rhs.fragments)
+    }
+}

--- a/Sources/SQLKit/Query/SQLQueryString.swift
+++ b/Sources/SQLKit/Query/SQLQueryString.swift
@@ -7,27 +7,31 @@ public struct SQLQueryString {
     
     var fragments: [Fragment]
     
+    init(fragments: [Fragment]) {
+        self.fragments = fragments
+    }
+    
     public init<S: StringProtocol>(_ string: S) {
-        fragments = [.literal(string.description)]
+        self.init(fragments: [.literal(string.description)])
     }
 }
 
 extension SQLQueryString: ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
-        fragments = [.literal(value)]
+        self.init(fragments: [.literal(value)])
     }
 }
 
 extension SQLQueryString: ExpressibleByStringInterpolation {
     
     public init(stringInterpolation: SQLQueryString) {
-        fragments = stringInterpolation.fragments
+        self.init(fragments: stringInterpolation.fragments)
     }
 }
 
 extension SQLQueryString: StringInterpolationProtocol {
     public init(literalCapacity: Int, interpolationCount: Int) {
-        fragments = []
+        self.init(fragments: [])
     }
     
     mutating public func appendLiteral(_ literal: String) {

--- a/Sources/SQLKit/Query/SQLQueryString.swift
+++ b/Sources/SQLKit/Query/SQLQueryString.swift
@@ -47,6 +47,10 @@ extension SQLQueryString: StringInterpolationProtocol {
     mutating public func appendInterpolation(binds values: [Encodable]) {
         fragments.append(.values(values))
     }
+    
+    mutating public func appendInterpolation(_ queryString: SQLQueryString) {
+        fragments.append(contentsOf: queryString.fragments)
+    }
 }
 
 extension SQLQueryString: SQLExpression {

--- a/Sources/SQLKit/Query/SQLQueryString.swift
+++ b/Sources/SQLKit/Query/SQLQueryString.swift
@@ -77,3 +77,18 @@ extension SQLQueryString {
         self.init(fragments: lhs.fragments + rhs.fragments)
     }
 }
+
+extension Array where Element == SQLQueryString {
+    public func joined(separator: String) -> SQLQueryString {
+        guard var fragments = self.first?.fragments else {
+            return ""
+        }
+        
+        for element in self.dropFirst() {
+            fragments.append(.literal(separator))
+            fragments.append(contentsOf: element.fragments)
+        }
+        
+        return SQLQueryString(fragments: fragments)
+    }
+}

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -83,6 +83,19 @@ final class SQLKitTests: XCTestCase {
         builder2.query.serialize(to: &serializer2)
         XCTAssertEqual(serializer2.sql, "SELECT * FROM staticTable WHERE name = uselessUnboundValue")
     }
+    
+    func testRawQueryStringWithPlus() throws {
+        let (table, planet) = ("planets", "Earth")
+        let query1: SQLQueryString = "SELECT * FROM \(table)"
+        let query2: SQLQueryString = " WHERE name = \(bind: planet)"
+        
+        let builder = db.raw(query1 + query2)
+        var serializer = SQLSerializer(database: db)
+        builder.query.serialize(to: &serializer)
+
+        XCTAssertEqual(serializer.sql, "SELECT * FROM planets WHERE name = ?")
+        XCTAssert(serializer.binds.first! as! String == "Earth")
+    }
 
     func testGroupByHaving() throws {
         try db.select().column("*")

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -58,7 +58,8 @@ final class SQLKitTests: XCTestCase {
     
     func testRawQueryStringInterpolation() throws {
         let (table, planet) = ("planets", "Earth")
-        let builder = db.raw("SELECT * FROM \(table) WHERE name = \(bind: planet)")
+        let whereClause: SQLQueryString = "WHERE name = \(bind: planet)"
+        let builder = db.raw("SELECT * FROM \(table) \(whereClause)")
         var serializer = SQLSerializer(database: db)
         builder.query.serialize(to: &serializer)
 

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -64,7 +64,7 @@ final class SQLKitTests: XCTestCase {
         builder.query.serialize(to: &serializer)
 
         XCTAssertEqual(serializer.sql, "SELECT * FROM planets WHERE name = ?")
-        XCTAssert(serializer.binds.first! as! String == "Earth")
+        XCTAssert(serializer.binds.first! as! String == planet)
     }
     
     func testRawQueryStringWithNonliteral() throws {
@@ -94,7 +94,7 @@ final class SQLKitTests: XCTestCase {
         builder.query.serialize(to: &serializer)
 
         XCTAssertEqual(serializer.sql, "SELECT * FROM planets WHERE name = ?")
-        XCTAssert(serializer.binds.first! as! String == "Earth")
+        XCTAssert(serializer.binds.first! as! String == planet)
     }
     
     func testRawQueryStringWithJoin() throws {
@@ -110,9 +110,9 @@ final class SQLKitTests: XCTestCase {
         builder.query.serialize(to: &serializer)
 
         XCTAssertEqual(serializer.sql, "SELECT * FROM planets WHERE name = ? OR name = ? OR name = ?")
-        XCTAssert(serializer.binds[0] as! String == "Earth")
-        XCTAssert(serializer.binds[1] as! String == "Mars")
-        XCTAssert(serializer.binds[2] as! String == "Saturn")
+        XCTAssert(serializer.binds[0] as! String == planet1)
+        XCTAssert(serializer.binds[1] as! String == planet2)
+        XCTAssert(serializer.binds[2] as! String == planet3)
     }
 
     func testGroupByHaving() throws {


### PR DESCRIPTION
Currently `SQLQueryString` can be constructed only through string literals and interpolations.
But we often want to build it conditionally.
This PR adds 3 functions to help constructing it:

- `SQLQueryString.stringInterpolation(SQLQueryString)`
- `+(SQLQueryString, SQLQueryString)`
- `[SQLQueryString].joined(separator: String)`

The test cases describe  how to use them and their usefulness.

I'm new to Vapor4 so if there already be alternative way to construct raw queries, please tell me.