### PR TITLE
Add additional interpolations, constructors, and operations to SQLQueryString

### DIFF
--- a/Sources/SQLKit/Query/SQLQueryString.swift
+++ b/Sources/SQLKit/Query/SQLQueryString.swift
@@ -1,49 +1,58 @@
 public struct SQLQueryString {
     var fragments: [SQLExpression]
     
+    /// Create a query string from a plain string containing raw SQL.
     public init<S: StringProtocol>(_ string: S) {
         self.fragments = [SQLRaw(string.description)]
     }
 }
 
 extension SQLQueryString: ExpressibleByStringLiteral {
+    /// See `ExpressibleByStringLiteral.init(stringLiteral:)`
     public init(stringLiteral value: String) {
         self.init(value)
     }
 }
 
 extension SQLQueryString: ExpressibleByStringInterpolation {
-    
+    /// See `ExpressibleByStringInterpolation.init(stringInterpolation:)`
     public init(stringInterpolation: SQLQueryString) {
         self.fragments = stringInterpolation.fragments
     }
 }
 
 extension SQLQueryString: StringInterpolationProtocol {
+    /// See `StringInterpolationProtocol.init(literalCapacity:interpolationCount:)`
     public init(literalCapacity: Int, interpolationCount: Int) {
         self.fragments = []
     }
     
+    /// Adds raw SQL to the string. Despite the use of the term "literal" dictated by the interpolation protocol, this
+    /// produces `SQLRaw` content, _not_ SQL string literals.
     mutating public func appendLiteral(_ literal: String) {
         self.fragments.append(SQLRaw(literal))
     }
     
+    /// Adds an interpolated string of raw SQL. Despite the use of the term "literal" dictated by the interpolation
+    /// protocol, this produces `SQLRaw` content, _not_ SQL string literals.
     mutating public func appendInterpolation(_ literal: String) {
         self.fragments.append(SQLRaw(literal))
     }
-
+    
+    /// Embed an `Encodable` value as a binding in the SQL query.
     mutating public func appendInterpolation(bind value: Encodable) {
         self.fragments.append(SQLBind(value))
     }
 
-    /// Binds multiple values in a comma separated list.
-    /// Commonly used with the `IN` operator.
+    /// Embed multiple `Encodable` values as bindings in the SQL query, separating the bind placeholders with commas.
+    /// Most commonly useful when working with the `IN` operator.
     mutating public func appendInterpolation(binds values: [Encodable]) {
         self.fragments.append(SQLList(values.map(SQLBind.init)))
     }
 }
 
 extension SQLQueryString: SQLExpression {
+    /// See `SQLExpression.serialize(to:)`
     public func serialize(to serializer: inout SQLSerializer) {
         self.fragments.forEach { $0.serialize(to: &serializer) }
     }

--- a/Sources/SQLKit/Query/SQLQueryString.swift
+++ b/Sources/SQLKit/Query/SQLQueryString.swift
@@ -108,6 +108,12 @@ extension SQLQueryString: StringInterpolationProtocol {
     }
 }
 
+extension SQLQueryString {
+    public static func +(lhs: SQLQueryString, rhs: SQLQueryString) -> SQLQueryString {
+        return "\(lhs)\(rhs)"
+    }
+}
+
 extension SQLQueryString: SQLExpression {
     /// See `SQLExpression.serialize(to:)`
     public func serialize(to serializer: inout SQLSerializer) {

--- a/Sources/SQLKit/Query/SQLQueryString.swift
+++ b/Sources/SQLKit/Query/SQLQueryString.swift
@@ -114,6 +114,14 @@ extension SQLQueryString {
     }
 }
 
+extension Array where Element == SQLQueryString {
+    public func joined(separator: String) -> SQLQueryString {
+        let separator = "\(separator)" as SQLQueryString
+        
+        return self.first.map { self.dropFirst().lazy.reduce($0) { $0 + separator + $1 } } ?? ""
+    }
+}
+
 extension SQLQueryString: SQLExpression {
     /// See `SQLExpression.serialize(to:)`
     public func serialize(to serializer: inout SQLSerializer) {

--- a/Tests/SQLKitTests/SQLQueryStringTests.swift
+++ b/Tests/SQLKitTests/SQLQueryStringTests.swift
@@ -74,4 +74,15 @@ final class SQLQueryStringTests: XCTestCase {
                 expression embeds: RESTRICT and CASCADE
             """)
     }
+    
+    func testAppendingQueryStringByOperatorPlus() throws {
+        var serializer = SQLSerializer(database: db)
+        let builder = db.raw(
+            "INSERT INTO \(ident: "anything") " as SQLQueryString +
+            "(\(idents: ["col1", "col2", "col3"], joinedBy: ",")) " as SQLQueryString +
+            "VALUES (\(binds: [1, 2, 3]))" as SQLQueryString
+        )
+        builder.query.serialize(to: &serializer)
+        XCTAssertEqual(serializer.sql, "INSERT INTO `anything` (`col1`,`col2`,`col3`) VALUES (?, ?, ?)")
+    }
 }

--- a/Tests/SQLKitTests/SQLQueryStringTests.swift
+++ b/Tests/SQLKitTests/SQLQueryStringTests.swift
@@ -85,4 +85,14 @@ final class SQLQueryStringTests: XCTestCase {
         builder.query.serialize(to: &serializer)
         XCTAssertEqual(serializer.sql, "INSERT INTO `anything` (`col1`,`col2`,`col3`) VALUES (?, ?, ?)")
     }
+    
+    func testQueryStringArrayJoin() throws {
+        var serializer = SQLSerializer(database: db)
+        let builder = db.raw(
+            "INSERT INTO \(ident: "anything") " as SQLQueryString +
+            ((0..<5).map { "\(literal: "\($0)")" as SQLQueryString }).joined(separator: "..")
+        )
+        builder.query.serialize(to: &serializer)
+        XCTAssertEqual(serializer.sql, "INSERT INTO `anything` '0'..'1'..'2'..'3'..'4'")
+    }
 }

--- a/Tests/SQLKitTests/SQLQueryStringTests.swift
+++ b/Tests/SQLKitTests/SQLQueryStringTests.swift
@@ -17,7 +17,7 @@ final class SQLQueryStringTests: XCTestCase {
         builder.query.serialize(to: &serializer)
 
         XCTAssertEqual(serializer.sql, "SELECT * FROM planets WHERE name = ?")
-        XCTAssertEqual(serializer.binds.first! as! String, "Earth")
+        XCTAssertEqual(serializer.binds.first! as! String, planet)
     }
     
     func testRawQueryStringWithNonliteral() throws {

--- a/Tests/SQLKitTests/SQLQueryStringTests.swift
+++ b/Tests/SQLKitTests/SQLQueryStringTests.swift
@@ -1,0 +1,77 @@
+import SQLKit
+import SQLKitBenchmark
+import XCTest
+
+final class SQLQueryStringTests: XCTestCase {
+    var db: TestDatabase!
+
+    override func setUp() {
+        super.setUp()
+        self.db = TestDatabase()
+    }
+
+    func testRawQueryStringInterpolation() throws {
+        let (table, planet) = ("planets", "Earth")
+        let builder = db.raw("SELECT * FROM \(table) WHERE name = \(bind: planet)")
+        var serializer = SQLSerializer(database: db)
+        builder.query.serialize(to: &serializer)
+
+        XCTAssertEqual(serializer.sql, "SELECT * FROM planets WHERE name = ?")
+        XCTAssertEqual(serializer.binds.first! as! String, "Earth")
+    }
+    
+    func testRawQueryStringWithNonliteral() throws {
+        let (table, planet) = ("planets", "Earth")
+
+        var serializer1 = SQLSerializer(database: db)
+        let query1 = "SELECT * FROM \(table) WHERE name = \(planet)"
+        let builder1 = db.raw(.init(query1))
+        builder1.query.serialize(to: &serializer1)
+        XCTAssertEqual(serializer1.sql, "SELECT * FROM planets WHERE name = Earth")
+
+        var serializer2 = SQLSerializer(database: db)
+        let query2: Substring = "|||SELECT * FROM staticTable WHERE name = uselessUnboundValue|||".dropFirst(3).dropLast(3)
+        let builder2 = db.raw(.init(query2))
+        builder2.query.serialize(to: &serializer2)
+        XCTAssertEqual(serializer2.sql, "SELECT * FROM staticTable WHERE name = uselessUnboundValue")
+    }
+
+    func testMakeQueryStringWithoutRawBuilder() throws {
+        let queryString = SQLQueryString("query with \(ident: "identifier") and stuff")
+        var serializer = SQLSerializer(database: db)
+        let builder = db.raw(queryString)
+        builder.query.serialize(to: &serializer)
+        XCTAssertEqual(serializer.sql, "query with `identifier` and stuff")
+    }
+    
+    func testAllQueryStringInterpolationTypes() throws {
+        var serializer = SQLSerializer(database: db)
+        let builder = db.raw("""
+            Query string embeds:
+                \("plain string embed")
+                \(bind: "single bind embed")
+                \(binds: ["multi-bind embed one", "multi-bind embed two"])
+                numeric literal embed \(literal: 1)
+                boolean literal embeds \(true) and \(false)
+                \(literal: "string literal embed")
+                \(literals: ["multi-literal embed one", "multi-literal embed two"], joinedBy: " || ")
+                \(ident: "string identifier embed")
+                \(idents: ["multi-ident embed one", "multi-ident embed two"], joinedBy: " + ")
+                expression embeds: \(SQLDropBehavior.restrict) and \(SQLDropBehavior.cascade)
+            """)
+        builder.query.serialize(to: &serializer)
+        XCTAssertEqual(serializer.sql, """
+            Query string embeds:
+                plain string embed
+                ?
+                ?, ?
+                numeric literal embed 1
+                boolean literal embeds true and false
+                'string literal embed'
+                'multi-literal embed one' || 'multi-literal embed two'
+                `string identifier embed`
+                `multi-ident embed one` + `multi-ident embed two`
+                expression embeds: RESTRICT and CASCADE
+            """)
+    }
+}


### PR DESCRIPTION
Several new capabilities are available on `SQLQueryString`, as used by `SQLRawBuilder`:

- Integer literal interpolation, e.g. `\(literal: 1)`, for rendering correctly escaped numeric literals according to the database's `SQLDialect`
- Boolean literal interpolation, e.g. `\(literal: true)`, for rendering correctly escaped boolean literals according to the database's `SQLDialect`
- String literal interpolation, e.g. `\(literal: "hello")`, for rendering strings as correctly escaped literal values in the database's `SQLDialect`
- Arrays of string literals interpolation, e.g. `\(literals: ["hello", "world", "how", "are", "you"], joinedBy: " ")`
- SQL identifier interpolation, e.g. `\(ident: "created_at")`, for rendering names as correctly escaped identifiers according to the database's `SQLDialect` - identifiers are usually table names, column names, alias names for tables and columns, and other similar items. PostgreSQL and SQLite enclose identifiers in `"` characters; MySQL uses backticks.
- Arrays of SQL identifiers interpolation, e.g. `\(idents: ["id", "created_at", "updated_at"], joinedBy: ", ")` - great for generating column name lists for `INSERT`, for example.
- A `+` operator for concatenating two `SQLQueryString`s. Credit for this functionality goes to @t-ae in #111.
- `Array<SQLQueryString>.joined(separator:)`, similar to `Array<String>.joined(separator:)`. Credit for this functionality goes to @t-ae in #111.
- Improved tests for `SQLQueryString`. Partial credit for the improvements goes to @t-ae in #111.