### PR TITLE
Fix `SQLReturningBuilder` not having `SQLQueryFetcher` methods available

### DIFF
--- a/Sources/SQLKit/Builders/SQLReturningBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLReturningBuilder.swift
@@ -9,8 +9,8 @@ extension SQLReturningBuilder {
     ///
     /// - parameters:
     ///     - columns: The names of the columns to return.
-    /// - returns: Self for chaining.
-    public func returning(_ columns: String...) -> Self {
+    /// - returns: `SQLReturningResultBuilder` to complete the chain.
+    public func returning(_ columns: String...) -> SQLReturningResultBuilder<Self> {
         let sqlColumns = columns.map { (column) -> SQLColumn in
             if column == "*" {
                 return SQLColumn(SQLLiteral.all)
@@ -20,7 +20,7 @@ extension SQLReturningBuilder {
         }
 
         self.returning = .init(sqlColumns)
-        return self
+        return SQLReturningResultBuilder(self)
     }
 
     /// Specify a list of columns to be returned as the result of the query.
@@ -28,10 +28,10 @@ extension SQLReturningBuilder {
     ///
     /// - parameters:
     ///     - columns: A list of expressions identifying the columns to return.
-    /// - returns: Self for chaining.
-    public func returning(_ columns: SQLExpression...) -> Self {
+    /// - returns: `SQLReturningResultBuilder` to complete the chain.
+    public func returning(_ columns: SQLExpression...) -> SQLReturningResultBuilder<Self> {
         self.returning = .init(columns)
-        return self
+        return SQLReturningResultBuilder(self)
     }
 
     /// Specify a list of columns to be returned as the result of the query.
@@ -39,9 +39,22 @@ extension SQLReturningBuilder {
     ///
     /// - parameters:
     ///     - column: An array of expressions identifying the columns to return.
-    /// - returns: Self for chaining.
-    public func returning(_ columns: [SQLExpression]) -> Self {
+    /// - returns: `SQLReturningResultBuilder` to complete the chain.
+    public func returning(_ columns: [SQLExpression]) -> SQLReturningResultBuilder<Self> {
         self.returning = .init(columns)
-        return self
+        return SQLReturningResultBuilder(self)
+    }
+}
+
+/// Return type from `SQLReturningBuilder` methods which allows `SQLQueryFetcher` calls
+/// such as `first()` and `all()`. Therefore `returning(...)` must be the second last method
+/// in the query chain.
+public final class SQLReturningResultBuilder<QueryBuilder: SQLQueryBuilder>: SQLQueryFetcher {
+    public var query: SQLExpression
+    public var database: SQLDatabase
+
+    init(_ builder: QueryBuilder) {
+        query = builder.query
+        database = builder.database
     }
 }

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -268,15 +268,15 @@ final class SQLKitTests: XCTestCase {
             .run().wait()
         XCTAssertEqual(db.results[0], "INSERT INTO `planets` (`name`) VALUES (?) RETURNING `id`, `name`")
 
-        try db.update("planets")
+        _ = try db.update("planets")
             .set("name", to: "Jupiter")
             .returning(SQLColumn("name", table: "planets"))
-            .run().wait()
+            .first().wait()
         XCTAssertEqual(db.results[1], "UPDATE `planets` SET `name` = ? RETURNING `planets`.`name`")
 
-        try db.delete(from: "planets")
+        _ = try db.delete(from: "planets")
             .returning("*")
-            .run().wait()
+            .all().wait()
         XCTAssertEqual(db.results[2], "DELETE FROM `planets` RETURNING *")
     }
 }


### PR DESCRIPTION
This fixes a mistake in #110, as you can't actually use it as intended and as the examples showed.

Should be able to write a query like this using the query builders:
```swift
db.delete()
  .from("planets")
  .returning("*")
  .all()
```

However currently `all()` is not available, as well as the other `SQLQueryFetcher` methods like `first()`. My initial thought was to make `SQLReturningBuilder` extend from `SQLQueryFetcher` instead of just `SQLQueryBuilder` however that would allow queries like the following:
```swift
db.delete()
  .from("planets")
  .all()
```

Since that would be misleading and undesired, `SQLReturningBuilder` methods now return a `SQLReturningResultBuilder` which conforms to `SQLQueryFetcher` allowing the desired behaviour, only when used with `returning(...)` statements. This does mean that `returning(...)` must be the second last method in the chain, but I think that makes sense.