### PR TITLE
Use 'raw' label for sql query interpolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 Package.resolved
 DerivedData
 .swiftpm
-
+Tests/LinuxMain.swift

--- a/Sources/SQLKit/Query/SQLQueryString.swift
+++ b/Sources/SQLKit/Query/SQLQueryString.swift
@@ -29,7 +29,7 @@ extension SQLQueryString: StringInterpolationProtocol {
     
     /// Adds raw SQL to the string. Despite the use of the term "literal" dictated by the interpolation protocol, this
     /// produces `SQLRaw` content, _not_ SQL string literals.
-    mutating public func appendLiteral(_ literal: String) {
+    public mutating func appendLiteral(_ literal: String) {
         self.fragments.append(SQLRaw(literal))
     }    
     
@@ -42,35 +42,35 @@ extension SQLQueryString: StringInterpolationProtocol {
     
     /// Adds an interpolated string of raw SQL. Despite the use of the term "literal" dictated by the interpolation
     /// protocol, this produces `SQLRaw` content, _not_ SQL string literals.
-    mutating public func appendInterpolation(raw value: CustomStringConvertible) {
+    public mutating func appendInterpolation(raw value: CustomStringConvertible) {
         self.fragments.append(SQLRaw(value.description))
     }
     
     /// Embed an `Encodable` value as a binding in the SQL query.
-    mutating public func appendInterpolation(bind value: Encodable) {
+    public mutating func appendInterpolation(bind value: Encodable) {
         self.fragments.append(SQLBind(value))
     }
 
     /// Embed multiple `Encodable` values as bindings in the SQL query, separating the bind placeholders with commas.
     /// Most commonly useful when working with the `IN` operator.
-    mutating public func appendInterpolation(binds values: [Encodable]) {
+    public mutating func appendInterpolation(binds values: [Encodable]) {
         self.fragments.append(SQLList(values.map(SQLBind.init)))
     }
     
     /// Embed an integer as a literal value, as if via `SQLLiteral.numeric()`
     /// Use this preferentially to ensure values are appropriately represented in the database's dialect.
-    mutating public func appendInterpolation<I: BinaryInteger>(literal: I) {
+    public mutating func appendInterpolation<I: BinaryInteger>(literal: I) {
         self.fragments.append(SQLLiteral.numeric("\(literal)"))
     }
 
     /// Embed a `Bool` as a literal value, as if via `SQLLiteral.boolean()`
-    mutating public func appendInterpolation(_ value: Bool) {
+    public mutating func appendInterpolation(_ value: Bool) {
         self.fragments.append(SQLLiteral.boolean(value))
     }
 
     /// Embed a `String` as a literal value, as if via `SQLLiteral.string()`
     /// Use this preferentially to ensure string values are appropriately represented in the database's dialect.
-    mutating public func appendInterpolation(literal: String) {
+    public mutating func appendInterpolation(literal: String) {
         self.fragments.append(SQLLiteral.string(literal))
     }
 
@@ -83,14 +83,14 @@ extension SQLQueryString: StringInterpolationProtocol {
     /// Rendered by the SQLite dialect:
     ///
     ///     SELECT 'a'||'b'||'c'||'d' FROM nowhere
-    mutating public func appendInterpolation(literals: [String], joinedBy joiner: String) {
+    public mutating func appendInterpolation(literals: [String], joinedBy joiner: String) {
         self.fragments.append(SQLList(literals.map(SQLLiteral.string(_:)), separator: SQLRaw(joiner)))
     }
 
     /// Embed a `String` as an SQL identifier, as if with `SQLIdentifier`
     /// Use this preferentially to ensure table names, column names, and other non-keyword identifiers are appropriately
     /// represented in the database's dialect.
-    mutating public func appendInterpolation(ident: String) {
+    public mutating func appendInterpolation(ident: String) {
         self.fragments.append(SQLIdentifier(ident))
     }
 
@@ -105,12 +105,12 @@ extension SQLQueryString: StringInterpolationProtocol {
     /// Rendered by the SQLite dialect:
     ///
     ///     SELECT "a", "b", "c", "d" FROM "nowhere"
-    mutating public func appendInterpolation(idents: [String], joinedBy joiner: String) {
+    public mutating func appendInterpolation(idents: [String], joinedBy joiner: String) {
         self.fragments.append(SQLList(idents.map(SQLIdentifier.init(_:)), separator: SQLRaw(joiner)))
     }
 
     /// Embed any `SQLExpression` into the string, to be serialized according to its type.
-    mutating public func appendInterpolation(_ expression: SQLExpression) {
+    public mutating func appendInterpolation(_ expression: SQLExpression) {
         self.fragments.append(expression)
     }
 }

--- a/Sources/SQLKit/Query/SQLQueryString.swift
+++ b/Sources/SQLKit/Query/SQLQueryString.swift
@@ -31,12 +31,19 @@ extension SQLQueryString: StringInterpolationProtocol {
     /// produces `SQLRaw` content, _not_ SQL string literals.
     mutating public func appendLiteral(_ literal: String) {
         self.fragments.append(SQLRaw(literal))
+    }    
+    
+    /// Adds an interpolated string of raw SQL. Despite the use of the term "literal" dictated by the interpolation
+    /// protocol, this produces `SQLRaw` content, _not_ SQL string literals.
+    @available(*, deprecated, message: "Use 'raw' label")
+    public mutating func appendInterpolation(_ literal: String) {
+        self.fragments.append(SQLRaw(literal))
     }
     
     /// Adds an interpolated string of raw SQL. Despite the use of the term "literal" dictated by the interpolation
     /// protocol, this produces `SQLRaw` content, _not_ SQL string literals.
-    mutating public func appendInterpolation(_ literal: String) {
-        self.fragments.append(SQLRaw(literal))
+    mutating public func appendInterpolation(raw value: CustomStringConvertible) {
+        self.fragments.append(SQLRaw(value.description))
     }
     
     /// Embed an `Encodable` value as a binding in the SQL query.
@@ -116,8 +123,7 @@ extension SQLQueryString {
 
 extension Array where Element == SQLQueryString {
     public func joined(separator: String) -> SQLQueryString {
-        let separator = "\(separator)" as SQLQueryString
-        
+        let separator = "\(raw: separator)" as SQLQueryString
         return self.first.map { self.dropFirst().lazy.reduce($0) { $0 + separator + $1 } } ?? ""
     }
 }

--- a/Sources/SQLKit/Query/SQLQueryString.swift
+++ b/Sources/SQLKit/Query/SQLQueryString.swift
@@ -42,7 +42,7 @@ extension SQLQueryString: StringInterpolationProtocol {
     
     /// Adds an interpolated string of raw SQL. Despite the use of the term "literal" dictated by the interpolation
     /// protocol, this produces `SQLRaw` content, _not_ SQL string literals.
-    public mutating func appendInterpolation(raw value: CustomStringConvertible) {
+    public mutating func appendInterpolation(raw value: String) {
         self.fragments.append(SQLRaw(value.description))
     }
     

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -279,11 +279,20 @@ final class SQLKitTests: XCTestCase {
             .all().wait()
         XCTAssertEqual(db.results[2], "DELETE FROM `planets` RETURNING *")
     }
-}
 
-// MARK: Table Creation
+    func testRawCustomStringConvertible() throws {
+        struct MyField: CustomStringConvertible {
+            var description: String {
+                "foo"
+            }
+        }
+        let db = TestDatabase()
+        _ = try db.raw("SELECT \(raw: MyField()) FROM users").all().wait()
+        XCTAssertEqual(db.results[0], "SELECT foo FROM users")
+    }
 
-extension SQLKitTests {
+    // MARK: Table Creation
+
     func testColumnConstraints() throws {
         try db.create(table: "planets")
             .column("id", type: .bigint, .primaryKey)

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -281,14 +281,10 @@ final class SQLKitTests: XCTestCase {
     }
 
     func testRawCustomStringConvertible() throws {
-        struct MyField: CustomStringConvertible {
-            var description: String {
-                "foo"
-            }
-        }
+        let field = "name"
         let db = TestDatabase()
-        _ = try db.raw("SELECT \(raw: MyField()) FROM users").all().wait()
-        XCTAssertEqual(db.results[0], "SELECT foo FROM users")
+        _ = try db.raw("SELECT \(raw: field) FROM users").all().wait()
+        XCTAssertEqual(db.results[0], "SELECT name FROM users")
     }
 
     // MARK: Table Creation

--- a/Tests/SQLKitTests/SQLQueryStringTests.swift
+++ b/Tests/SQLKitTests/SQLQueryStringTests.swift
@@ -12,7 +12,7 @@ final class SQLQueryStringTests: XCTestCase {
 
     func testRawQueryStringInterpolation() throws {
         let (table, planet) = ("planets", "Earth")
-        let builder = db.raw("SELECT * FROM \(table) WHERE name = \(bind: planet)")
+        let builder = db.raw("SELECT * FROM \(raw: table) WHERE name = \(bind: planet)")
         var serializer = SQLSerializer(database: db)
         builder.query.serialize(to: &serializer)
 
@@ -48,7 +48,7 @@ final class SQLQueryStringTests: XCTestCase {
         var serializer = SQLSerializer(database: db)
         let builder = db.raw("""
             Query string embeds:
-                \("plain string embed")
+                \(raw: "plain string embed")
                 \(bind: "single bind embed")
                 \(binds: ["multi-bind embed one", "multi-bind embed two"])
                 numeric literal embed \(literal: 1)


### PR DESCRIPTION
Deprecates the old raw SQL string interpolation and adds a new one with `raw` label (#114).

```swift
let field = "name"
let results = try db.raw("SELECT \(raw: field) FROM users").all().wait()
```