### PR TITLE
Added check to run MySQL benchmarks using TEXT field for .text

### DIFF
--- a/Sources/SQLKitBenchmark/SQLBenchmark+Planets.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmark+Planets.swift
@@ -3,7 +3,7 @@ import SQLKit
 
 extension SQLBenchmarker {
     func testPlanets() throws {
-	let textType:SQLDataType = ( db.dialect.name == "mysql" ) ? .text : .custom( SQLRaw("TEXT") ) 
+	let textType:SQLDataType = ( db.dialect.name == "mysql" ) ? .custom( SQLRaw("VARCHAR(255)") ) : .text
         try self.db.drop(table: "planets")
             .ifExists()
             .run().wait()

--- a/Sources/SQLKitBenchmark/SQLBenchmark+Planets.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmark+Planets.swift
@@ -3,7 +3,7 @@ import SQLKit
 
 extension SQLBenchmarker {
     func testPlanets() throws {
-	let textType:SQLDataType = ( db.dialect.name == "mysql" ) ? .custom( SQLRaw("TEXT") ) : .text 
+	let textType:SQLDataType = ( db.dialect.name == "mysql" ) ? .text : .custom( SQLRaw("TEXT") ) 
         try self.db.drop(table: "planets")
             .ifExists()
             .run().wait()

--- a/Sources/SQLKitBenchmark/SQLBenchmark+Planets.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmark+Planets.swift
@@ -3,6 +3,7 @@ import SQLKit
 
 extension SQLBenchmarker {
     func testPlanets() throws {
+	let textType:SQLDataType = ( db.dialect.name == "mysql" ) ? .custom( SQLRaw("TEXT") ) : .text 
         try self.db.drop(table: "planets")
             .ifExists()
             .run().wait()
@@ -11,7 +12,7 @@ extension SQLBenchmarker {
             .run().wait()
         try self.db.create(table: "galaxies")
             .column("id", type: .bigint, .primaryKey)
-            .column("name", type: .text)
+            .column("name", type: textType)
             .run().wait()
         try self.db.create(table: "planets")
             .ifNotExists()
@@ -19,7 +20,7 @@ extension SQLBenchmarker {
             .column("galaxyID", type: .bigint, .references("galaxies", "id"))
             .run().wait()
         try self.db.alter(table: "planets")
-            .column("name", type: .text, .default(SQLLiteral.string("Unamed Planet")))
+            .column("name", type: textType, .default(SQLLiteral.string("Unamed Planet")))
             .run().wait()
         try self.db.create(index: "test_index")
             .on("planets")


### PR DESCRIPTION
There is an issue open in vapor/mysql-kit to change the underlying raw SQL type for `.text` fields to `TEXT`. However, simply making this changes causes tests to fail in SQLKitBenchmarks because not all dialects of SQL support default values for TEXT fields. @tanner0101 suggested changing the test to check for the dialect and create an appropriate column type. I think this PR does this.