### PR TITLE
Resurrect support for Codables with nullable fields

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.image }}
     steps:
-      - uses: maxim-lobanov/setup-xcode@1.0
+      - uses: maxim-lobanov/setup-xcode@v1
         with: { 'xcode-version': 'latest' }
         if: ${{ matrix.os == 'macos-latest' }}
       - uses: actions/checkout@v2

--- a/Sources/SQLKit/SQLQueryEncoder.swift
+++ b/Sources/SQLKit/SQLQueryEncoder.swift
@@ -94,6 +94,29 @@ private final class _Encoder: Encoder {
             }
         }
 
+      mutating func _encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T : Encodable {
+        if let value = value {
+          try encode(value, forKey: key)
+        } else {
+          try encodeNil(forKey: key)
+        }
+      }
+
+      mutating func encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T : Encodable { try _encodeIfPresent(value, forKey: key)}
+      mutating func encodeIfPresent(_ value: Int?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: Int8?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: Int16?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: Int32?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: Int64?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: UInt?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: UInt16?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: UInt32?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: UInt64?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: Double?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: Float?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: String?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: Bool?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+
         mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
             fatalError()
         }

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -280,6 +280,39 @@ final class SQLKitTests: XCTestCase {
         XCTAssertEqual(db.results[2], "DELETE FROM `planets` RETURNING *")
     }
 
+    func testCodableWithNillableColumnWithNonnilValue() throws {
+        struct Gas: Codable {
+            let name: String
+            let color: String?
+        }
+        let db = TestDatabase()
+        var serializer = SQLSerializer(database: db)
+
+        let insertBuilder = try db.insert(into: "gasses").model(Gas(name: "iodine", color: "purple"))
+        insertBuilder.insert.serialize(to: &serializer)
+
+        XCTAssertEqual(serializer.sql, "INSERT INTO `gasses` (`name`, `color`) VALUES (?, ?)")
+        XCTAssertEqual(serializer.binds.count, 2)
+        XCTAssertEqual(serializer.binds[0] as? String, "iodine")
+        XCTAssertEqual(serializer.binds[1] as? String, "purple")
+    }
+
+    func testCodableWithNillableColumnWithNilValue() throws {
+        struct Gas: Codable {
+            let name: String
+            let color: String?
+        }
+        let db = TestDatabase()
+        var serializer = SQLSerializer(database: db)
+
+        let insertBuilder = try db.insert(into: "gasses").model(Gas(name: "oxygen", color: nil))
+        insertBuilder.insert.serialize(to: &serializer)
+
+        XCTAssertEqual(serializer.sql, "INSERT INTO `gasses` (`name`, `color`) VALUES (?, NULL)")
+        XCTAssertEqual(serializer.binds.count, 1)
+        XCTAssertEqual(serializer.binds[0] as? String, "oxygen")
+    }
+
     func testRawCustomStringConvertible() throws {
         let field = "name"
         let db = TestDatabase()


### PR DESCRIPTION
When a type conforms to `Codable`, its nullable fields will now be encoded as null, which will correctly map to nullable fields in the database table (https://github.com/vapor/sql-kit/pull/122, fixes https://github.com/vapor/sql-kit/issues/121).
