### PR TITLE
Revert "Resurrect support for Codables with nullable fields (#122)"

### DIFF
--- a/Sources/SQLKit/SQLQueryEncoder.swift
+++ b/Sources/SQLKit/SQLQueryEncoder.swift
@@ -94,29 +94,6 @@ private final class _Encoder: Encoder {
             }
         }
 
-      mutating func _encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T : Encodable {
-        if let value = value {
-          try encode(value, forKey: key)
-        } else {
-          try encodeNil(forKey: key)
-        }
-      }
-
-      mutating func encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T : Encodable { try _encodeIfPresent(value, forKey: key)}
-      mutating func encodeIfPresent(_ value: Int?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: Int8?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: Int16?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: Int32?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: Int64?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: UInt?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: UInt16?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: UInt32?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: UInt64?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: Double?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: Float?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: String?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: Bool?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-
         mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
             fatalError()
         }

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -280,39 +280,6 @@ final class SQLKitTests: XCTestCase {
         XCTAssertEqual(db.results[2], "DELETE FROM `planets` RETURNING *")
     }
 
-    func testCodableWithNillableColumnWithNonnilValue() throws {
-        struct Gas: Codable {
-            let name: String
-            let color: String?
-        }
-        let db = TestDatabase()
-        var serializer = SQLSerializer(database: db)
-
-        let insertBuilder = try db.insert(into: "gasses").model(Gas(name: "iodine", color: "purple"))
-        insertBuilder.insert.serialize(to: &serializer)
-
-        XCTAssertEqual(serializer.sql, "INSERT INTO `gasses` (`name`, `color`) VALUES (?, ?)")
-        XCTAssertEqual(serializer.binds.count, 2)
-        XCTAssertEqual(serializer.binds[0] as? String, "iodine")
-        XCTAssertEqual(serializer.binds[1] as? String, "purple")
-    }
-
-    func testCodableWithNillableColumnWithNilValue() throws {
-        struct Gas: Codable {
-            let name: String
-            let color: String?
-        }
-        let db = TestDatabase()
-        var serializer = SQLSerializer(database: db)
-
-        let insertBuilder = try db.insert(into: "gasses").model(Gas(name: "oxygen", color: nil))
-        insertBuilder.insert.serialize(to: &serializer)
-
-        XCTAssertEqual(serializer.sql, "INSERT INTO `gasses` (`name`, `color`) VALUES (?, NULL)")
-        XCTAssertEqual(serializer.binds.count, 1)
-        XCTAssertEqual(serializer.binds[0] as? String, "oxygen")
-    }
-
     func testRawCustomStringConvertible() throws {
         let field = "name"
         let db = TestDatabase()


### PR DESCRIPTION
With apologies to @danramteke, this change reverts #122. Unfortunately, SQLKit's CI does not currently run the test suites of the various database drivers, which would have revealed that this change breaks the ability to use `GENERATED BY DEFAULT AS IDENTITY` columns (more commonly called auto-increment in other databases) in PostgreSQL.

For example, when using `SQLInsertBuilder.model(_:)`, in the past an unset `id` column in the input model would be left entirely unspecified in the resulting query, which is equivalent to specifying it explicitly with the `DEFAULT` keyword. With the `SQLQueryEncoder` changes in place, the column is given an explicit `NULL` value instead, which is not a valid input for a generated identifier column in PostgreSQL.

To make matters more confusing, `NULL` _is_ a valid input for MySQL's `AUTO_INCREMENT` and SQLite's `INTEGER PRIMARY KEY` - and of course, FluentKit does not rely on this particular piece of SQLKit for lowering models to query inputs. The result is that while this change invalidates invariants that Fluent does depend on, the problem only manifests when using PostgresKit via FluentPostgresDriver and the SQLKit layer.

Some additional study is needed to find a solution that does not invalidate Fluent's invariants. Ideally, a complete solution correctly manages the distinction between "unset non-optional", "unset optional", and "set but nil optional" values.