### PR TITLE
Allow Codables with nillable columns to encode as nil, if they wish

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,24 +9,9 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          # 5.2 Stable
-          - swift:5.2-xenial
-          - swift:5.2-bionic
           - swift:5.2-focal
-          - swift:5.2-centos8
-          - swift:5.2-amazonlinux2
-          # 5.2 Unstable
-          - swiftlang/swift:nightly-5.2-xenial
-          - swiftlang/swift:nightly-5.2-bionic
-          # 5.3 Unstable
-          - swiftlang/swift:nightly-5.3-xenial
-          - swiftlang/swift:nightly-5.3-bionic
-          # Main Unstable
-          - swiftlang/swift:nightly-master-xenial
-          - swiftlang/swift:nightly-master-bionic
+          - swift:5.3-focal
           - swiftlang/swift:nightly-master-focal
-          - swiftlang/swift:nightly-master-centos8
-          - swiftlang/swift:nightly-master-amazonlinux2
         include:
           - { os: 'ubuntu-latest' }
           - { os: 'macos-latest', image: '' }
@@ -40,7 +25,7 @@ jobs:
       - run: swift test --enable-test-discovery --sanitize=thread
   driver-integration_linux:
     runs-on: ubuntu-latest
-    container: swift:5.2-bionic
+    container: swift:5.3-focal
     services:
       psql:
         image: postgres:latest
@@ -49,8 +34,8 @@ jobs:
         image: mysql:latest
         env: { MYSQL_ALLOW_EMPTY_PASSWORD: true, MYSQL_DATABASE: vapor_database, MYSQL_USER: vapor_username, MYSQL_PASSWORD: vapor_password }
     env:
-      POSTGRES_HOSTNAME: ${{ matrix.psqlhost }}
-      MYSQL_HOSTNAME: ${{ matrix.mysqlhost }}
+      POSTGRES_HOSTNAME: psql
+      MYSQL_HOSTNAME: mysql
       MYSQL_TLS: true
     steps:
       - run: apt update -q && apt install -y libsqlite3-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         image:
           - swift:5.2-focal
           - swift:5.3-focal
-          - swiftlang/swift:nightly-master-focal
+          - swiftlang/swift:nightly-main-focal
         include:
           - { os: 'ubuntu-latest' }
           - { os: 'macos-latest', image: '' }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.image }}
     steps:
-      - uses: maxim-lobanov/setup-xcode@1.0
+      - uses: maxim-lobanov/setup-xcode@v1
         with: { 'xcode-version': 'latest' }
         if: ${{ matrix.os == 'macos-latest' }}
       - uses: actions/checkout@v2

--- a/Sources/SQLKit/Builders/SQLInsertBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLInsertBuilder.swift
@@ -36,14 +36,15 @@ public final class SQLInsertBuilder: SQLQueryBuilder, SQLReturningBuilder {
     /// - parameters:
     ///     - value: `Encodable` value to insert.
     /// - returns: Self for chaining.
-    public func model<E>(_ model: E, prefix: String? = nil, keyEncodingStrategy: SQLQueryEncoder.KeyEncodingStrategy = .useDefaultKeys) throws -> Self
+    public func model<E>(_ model: E, prefix: String? = nil, keyEncodingStrategy: SQLQueryEncoder.KeyEncodingStrategy = .useDefaultKeys, nilEncodingStrategy: SQLQueryEncoder.NilEncodingStrategy = .standard) throws -> Self
         where E: Encodable {
-            return try models([model], prefix: prefix, keyEncodingStrategy: keyEncodingStrategy)
+        return try models([model], prefix: prefix, keyEncodingStrategy: keyEncodingStrategy, nilEncodingStrategy: nilEncodingStrategy)
     }
 
-    public func models<E>(_ models: [E], prefix: String? = nil, keyEncodingStrategy: SQLQueryEncoder.KeyEncodingStrategy = .useDefaultKeys) throws -> Self where E: Encodable {
+    public func models<E>(_ models: [E], prefix: String? = nil, keyEncodingStrategy: SQLQueryEncoder.KeyEncodingStrategy = .useDefaultKeys, nilEncodingStrategy: SQLQueryEncoder.NilEncodingStrategy = .standard) throws -> Self where E: Encodable {
         var encoder = SQLQueryEncoder()
         encoder.keyEncodingStrategy = keyEncodingStrategy
+        encoder.nilEncodingStrategy = nilEncodingStrategy
         encoder.prefix = prefix
 
         for model in models {

--- a/Sources/SQLKit/Builders/SQLInsertBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLInsertBuilder.swift
@@ -36,12 +36,12 @@ public final class SQLInsertBuilder: SQLQueryBuilder, SQLReturningBuilder {
     /// - parameters:
     ///     - value: `Encodable` value to insert.
     /// - returns: Self for chaining.
-    public func model<E>(_ model: E, prefix: String? = nil, keyEncodingStrategy: SQLQueryEncoder.KeyEncodingStrategy = .useDefaultKeys, nilEncodingStrategy: SQLQueryEncoder.NilEncodingStrategy = .standard) throws -> Self
+    public func model<E>(_ model: E, prefix: String? = nil, keyEncodingStrategy: SQLQueryEncoder.KeyEncodingStrategy = .useDefaultKeys, nilEncodingStrategy: SQLQueryEncoder.NilEncodingStrategy = .default) throws -> Self
         where E: Encodable {
         return try models([model], prefix: prefix, keyEncodingStrategy: keyEncodingStrategy, nilEncodingStrategy: nilEncodingStrategy)
     }
 
-    public func models<E>(_ models: [E], prefix: String? = nil, keyEncodingStrategy: SQLQueryEncoder.KeyEncodingStrategy = .useDefaultKeys, nilEncodingStrategy: SQLQueryEncoder.NilEncodingStrategy = .standard) throws -> Self where E: Encodable {
+    public func models<E>(_ models: [E], prefix: String? = nil, keyEncodingStrategy: SQLQueryEncoder.KeyEncodingStrategy = .useDefaultKeys, nilEncodingStrategy: SQLQueryEncoder.NilEncodingStrategy = .default) throws -> Self where E: Encodable {
         var encoder = SQLQueryEncoder()
         encoder.keyEncodingStrategy = keyEncodingStrategy
         encoder.nilEncodingStrategy = nilEncodingStrategy

--- a/Sources/SQLKit/SQLQueryEncoder.swift
+++ b/Sources/SQLKit/SQLQueryEncoder.swift
@@ -94,6 +94,29 @@ private final class _Encoder: Encoder {
             }
         }
 
+      mutating func _encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T : Encodable {
+        if let value = value {
+          try encode(value, forKey: key)
+        } else {
+          try encodeNil(forKey: key)
+        }
+      }
+
+      mutating func encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T : Encodable { try _encodeIfPresent(value, forKey: key)}
+      mutating func encodeIfPresent(_ value: Int?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: Int8?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: Int16?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: Int32?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: Int64?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: UInt?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: UInt16?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: UInt32?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: UInt64?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: Double?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: Float?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: String?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+      mutating func encodeIfPresent(_ value: Bool?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+
         mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
             fatalError()
         }

--- a/Sources/SQLKit/SQLQueryEncoder.swift
+++ b/Sources/SQLKit/SQLQueryEncoder.swift
@@ -14,8 +14,10 @@ public struct SQLQueryEncoder {
     }
 
     public enum NilEncodingStrategy {
+        /// Standard nil encoding
         case standard
-        case asNull
+        /// Encodes nilable columns with nil values as nil. Useful when using `SQLInsertBuilder` to insert `Codable` models without Fluent
+        case asNil
     }
 
     public enum KeyEncodingStrategy {
@@ -61,7 +63,7 @@ private final class _Encoder: Encoder {
 
     func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
         switch options.nilEncodingStrategy {
-        case .asNull:
+        case .asNil:
             return KeyedEncodingContainer(_NilColumnKeyedEncoder(self))
         case .standard:
             return KeyedEncodingContainer(_KeyedEncoder(self))

--- a/Sources/SQLKit/SQLQueryEncoder.swift
+++ b/Sources/SQLKit/SQLQueryEncoder.swift
@@ -1,6 +1,7 @@
 public struct SQLQueryEncoder {
     public var prefix: String? = nil
     public var keyEncodingStrategy: KeyEncodingStrategy = .useDefaultKeys
+    public var nilEncodingStrategy: NilEncodingStrategy = .standard
 
     public init() { }
 
@@ -10,6 +11,11 @@ public struct SQLQueryEncoder {
         let encoder = _Encoder(options: options)
         try encodable.encode(to: encoder)
         return encoder.row
+    }
+
+    public enum NilEncodingStrategy {
+        case standard
+        case asNull
     }
 
     public enum KeyEncodingStrategy {
@@ -23,11 +29,15 @@ public struct SQLQueryEncoder {
     fileprivate struct _Options {
         let prefix: String?
         let keyEncodingStrategy: KeyEncodingStrategy
+        let nilEncodingStrategy: NilEncodingStrategy
     }
 
     /// The options set on the top-level decoder.
     fileprivate var options: _Options {
-        return _Options(prefix: prefix, keyEncodingStrategy: keyEncodingStrategy)
+        _Options(
+            prefix: prefix,
+            keyEncodingStrategy: keyEncodingStrategy,
+            nilEncodingStrategy: nilEncodingStrategy)
     }
 }
 
@@ -50,7 +60,101 @@ private final class _Encoder: Encoder {
     }
 
     func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
-        return KeyedEncodingContainer(_KeyedEncoder(self))
+        switch options.nilEncodingStrategy {
+        case .asNull:
+            return KeyedEncodingContainer(_NilColumnKeyedEncoder(self))
+        case .standard:
+            return KeyedEncodingContainer(_KeyedEncoder(self))
+        }
+    }
+
+    struct _NilColumnKeyedEncoder<Key>: KeyedEncodingContainerProtocol
+        where Key: CodingKey
+    {
+        var codingPath: [CodingKey] {
+            return []
+        }
+        let encoder: _Encoder
+        init(_ encoder: _Encoder) {
+            self.encoder = encoder
+        }
+
+        func column(for key: Key) -> String {
+            var encodedKey = key.stringValue
+            switch self.encoder.options.keyEncodingStrategy {
+            case .useDefaultKeys:
+                break
+            case .convertToSnakeCase:
+                encodedKey = _convertToSnakeCase(encodedKey)
+            case .custom(let customKeyEncodingFunc):
+                encodedKey = customKeyEncodingFunc([key]).stringValue
+            }
+
+            if let prefix = self.encoder.options.prefix {
+                return prefix + encodedKey
+            } else {
+                return encodedKey
+            }
+        }
+
+        mutating func encodeNil(forKey key: Key) throws {
+            self.encoder.row.append((self.column(for: key), SQLLiteral.null))
+        }
+
+        mutating func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
+            if let value = value as? SQLExpression {
+                self.encoder.row.append((self.column(for: key), value))
+            } else {
+                self.encoder.row.append((self.column(for: key), SQLBind(value)))
+            }
+        }
+
+        mutating func _encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T : Encodable {
+            if let value = value {
+                try encode(value, forKey: key)
+            } else {
+                try encodeNil(forKey: key)
+            }
+        }
+
+        mutating func encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T : Encodable { try _encodeIfPresent(value, forKey: key)}
+        mutating func encodeIfPresent(_ value: Int?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+        mutating func encodeIfPresent(_ value: Int8?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+        mutating func encodeIfPresent(_ value: Int16?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+        mutating func encodeIfPresent(_ value: Int32?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+        mutating func encodeIfPresent(_ value: Int64?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+        mutating func encodeIfPresent(_ value: UInt?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+        mutating func encodeIfPresent(_ value: UInt16?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+        mutating func encodeIfPresent(_ value: UInt32?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+        mutating func encodeIfPresent(_ value: UInt64?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+        mutating func encodeIfPresent(_ value: Double?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+        mutating func encodeIfPresent(_ value: Float?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+        mutating func encodeIfPresent(_ value: String?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+        mutating func encodeIfPresent(_ value: Bool?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
+
+        mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+            fatalError()
+        }
+
+        mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+            fatalError()
+        }
+
+        mutating func superEncoder() -> Encoder {
+            return self.encoder
+        }
+
+        mutating func superEncoder(forKey key: Key) -> Encoder {
+            return self.encoder
+        }
+    }
+
+    func unkeyedContainer() -> UnkeyedEncodingContainer {
+        fatalError()
+    }
+
+    func singleValueContainer() -> SingleValueEncodingContainer {
+        fatalError()
     }
 
     struct _KeyedEncoder<Key>: KeyedEncodingContainerProtocol
@@ -94,29 +198,6 @@ private final class _Encoder: Encoder {
             }
         }
 
-      mutating func _encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T : Encodable {
-        if let value = value {
-          try encode(value, forKey: key)
-        } else {
-          try encodeNil(forKey: key)
-        }
-      }
-
-      mutating func encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T : Encodable { try _encodeIfPresent(value, forKey: key)}
-      mutating func encodeIfPresent(_ value: Int?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: Int8?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: Int16?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: Int32?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: Int64?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: UInt?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: UInt16?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: UInt32?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: UInt64?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: Double?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: Float?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: String?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-      mutating func encodeIfPresent(_ value: Bool?, forKey key: Key) throws { try _encodeIfPresent(value, forKey: key) }
-
         mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
             fatalError()
         }
@@ -132,14 +213,14 @@ private final class _Encoder: Encoder {
         mutating func superEncoder(forKey key: Key) -> Encoder {
             return self.encoder
         }
-    }
 
-    func unkeyedContainer() -> UnkeyedEncodingContainer {
-        fatalError()
-    }
+        func unkeyedContainer() -> UnkeyedEncodingContainer {
+            fatalError()
+        }
 
-    func singleValueContainer() -> SingleValueEncodingContainer {
-        fatalError()
+        func singleValueContainer() -> SingleValueEncodingContainer {
+            fatalError()
+        }
     }
 }
 

--- a/Sources/SQLKit/SQLQueryEncoder.swift
+++ b/Sources/SQLKit/SQLQueryEncoder.swift
@@ -1,7 +1,7 @@
 public struct SQLQueryEncoder {
     public var prefix: String? = nil
     public var keyEncodingStrategy: KeyEncodingStrategy = .useDefaultKeys
-    public var nilEncodingStrategy: NilEncodingStrategy = .standard
+    public var nilEncodingStrategy: NilEncodingStrategy = .default
 
     public init() { }
 
@@ -14,8 +14,8 @@ public struct SQLQueryEncoder {
     }
 
     public enum NilEncodingStrategy {
-        /// Standard nil encoding
-        case standard
+        /// Skips nilable columns with nil values during encoding.
+        case `default`
         /// Encodes nilable columns with nil values as nil. Useful when using `SQLInsertBuilder` to insert `Codable` models without Fluent
         case asNil
     }
@@ -65,7 +65,7 @@ private final class _Encoder: Encoder {
         switch options.nilEncodingStrategy {
         case .asNil:
             return KeyedEncodingContainer(_NilColumnKeyedEncoder(self))
-        case .standard:
+        case .default:
             return KeyedEncodingContainer(_KeyedEncoder(self))
         }
     }

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -321,7 +321,7 @@ final class SQLKitTests: XCTestCase {
         let db = TestDatabase()
         var serializer = SQLSerializer(database: db)
 
-        let insertBuilder = try db.insert(into: "gasses").model(Gas(name: "oxygen", color: nil), nilEncodingStrategy: .asNull)
+        let insertBuilder = try db.insert(into: "gasses").model(Gas(name: "oxygen", color: nil), nilEncodingStrategy: .asNil)
         insertBuilder.insert.serialize(to: &serializer)
 
         XCTAssertEqual(serializer.sql, "INSERT INTO `gasses` (`name`, `color`) VALUES (?, NULL)")

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -280,6 +280,39 @@ final class SQLKitTests: XCTestCase {
         XCTAssertEqual(db.results[2], "DELETE FROM `planets` RETURNING *")
     }
 
+    func testCodableWithNillableColumnWithNonnilValue() throws {
+        struct Gas: Codable {
+            let name: String
+            let color: String?
+        }
+        let db = TestDatabase()
+        var serializer = SQLSerializer(database: db)
+
+        let insertBuilder = try db.insert(into: "gasses").model(Gas(name: "iodine", color: "purple"))
+        insertBuilder.insert.serialize(to: &serializer)
+
+        XCTAssertEqual(serializer.sql, "INSERT INTO `gasses` (`name`, `color`) VALUES (?, ?)")
+        XCTAssertEqual(serializer.binds.count, 2)
+        XCTAssertEqual(serializer.binds[0] as? String, "iodine")
+        XCTAssertEqual(serializer.binds[1] as? String, "purple")
+    }
+
+    func testCodableWithNillableColumnWithNilValue() throws {
+        struct Gas: Codable {
+            let name: String
+            let color: String?
+        }
+        let db = TestDatabase()
+        var serializer = SQLSerializer(database: db)
+
+        let insertBuilder = try db.insert(into: "gasses").model(Gas(name: "oxygen", color: nil))
+        insertBuilder.insert.serialize(to: &serializer)
+
+        XCTAssertEqual(serializer.sql, "INSERT INTO `gasses` (`name`, `color`) VALUES (?, NULL)")
+        XCTAssertEqual(serializer.binds.count, 1)
+        XCTAssertEqual(serializer.binds[0] as? String, "oxygen")
+    }
+
     func testRawCustomStringConvertible() throws {
         let field = "name"
         let db = TestDatabase()


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->

In #122 , we resurrected support for nillable columns, however, this caused some issues with downstream clients of this repo. 

With this release, we allow clients to opt-in to this behavior.

Here is an example:

```
struct Gas: Codable {
  let name: String
  let color: String?
}

let db = TestDatabase()
var serializer = SQLSerializer(database: db)

let insertBuilder = try db.insert(into: "gasses").model(Gas(name: "oxygen", color: nil), nilEncodingStrategy: .asNil)
insertBuilder.insert.serialize(to: &serializer)

XCTAssertEqual(serializer.sql, "INSERT INTO `gasses` (`name`, `color`) VALUES (?, NULL)")
XCTAssertEqual(serializer.binds.count, 1)
XCTAssertEqual(serializer.binds[0] as? String, "oxygen")
```

## Details

There is a new `NilEncodingStrategy` right next to the existing `KeyEncodingStrategy`. It defaults to the pre-existing behavior that works with Fluent. Clients of this library can pass in a nilEncodingStrategy option to opt-in to the nillable column behavior.