### PR TITLE
fix select query without from

### DIFF
--- a/Sources/SQLKit/Query/SQLSelect.swift
+++ b/Sources/SQLKit/Query/SQLSelect.swift
@@ -52,8 +52,10 @@ public struct SQLSelect: SQLExpression {
             serializer.write("DISTINCT ")
         }
         SQLList(self.columns).serialize(to: &serializer)
-        serializer.write(" FROM ")
-        SQLList(self.tables).serialize(to: &serializer)
+        if !self.tables.isEmpty {
+            serializer.write(" FROM ")
+            SQLList(self.tables).serialize(to: &serializer)
+        }
         if !self.joins.isEmpty {
             serializer.write(" ")
             SQLList(self.joins, separator: SQLRaw(" ")).serialize(to: &serializer)

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -23,6 +23,14 @@ final class SQLKitTests: XCTestCase {
         XCTAssertEqual(db.results[0], "SELECT * FROM `planets` WHERE `name` IN (?, ?)")
     }
 
+    func testSelect_withoutFrom() throws {
+        try db.select()
+            .column(SQLAlias.init(SQLFunction("LAST_INSERT_ID"), as: SQLIdentifier.init("id")))
+            .first()
+            .wait()
+        XCTAssertEqual(db.results[0], "SELECT LAST_INSERT_ID() as `id`")
+    }
+
     func testUpdate() throws {
         try db.update("planets")
             .where("name", .equal, "Jpuiter")

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -28,7 +28,7 @@ final class SQLKitTests: XCTestCase {
             .column(SQLAlias.init(SQLFunction("LAST_INSERT_ID"), as: SQLIdentifier.init("id")))
             .first()
             .wait()
-        XCTAssertEqual(db.results[0], "SELECT LAST_INSERT_ID() as `id`")
+        XCTAssertEqual(db.results[0], "SELECT LAST_INSERT_ID() AS `id`")
     }
 
     func testUpdate() throws {


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

Not all `SELECT` queries require a `FROM` statement. This pr fixes the query generation for queries without `FROM` and allows the following example to work:

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
```swift
conn.sql()
    .select()
    .column(SQLAlias.init(SQLFunction("LAST_INSERT_ID"), as: SQLIdentifier.init("id")))
    .first()
```