### PR TITLE
Fix warnings from Swift 5.4 compiler

### DIFF
--- a/Sources/SQLKit/Builders/SQLJoinBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLJoinBuilder.swift
@@ -1,4 +1,4 @@
-public protocol SQLJoinBuilder: class {
+public protocol SQLJoinBuilder: AnyObject {
     var joins: [SQLExpression] { get set }
 }
 

--- a/Sources/SQLKit/Builders/SQLPredicateBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLPredicateBuilder.swift
@@ -7,7 +7,7 @@
 ///     builder.where(\Planet.name == "Earth").orWhere(\Planet.name == "Mars")
 ///
 /// See `SQLPredicateGroupBuilder` for building expression groups.
-public protocol SQLPredicateBuilder: class {
+public protocol SQLPredicateBuilder: AnyObject {
     /// Expression being built.
     var predicate: SQLExpression? { get set }
 }

--- a/Sources/SQLKit/Builders/SQLQueryBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLQueryBuilder.swift
@@ -4,7 +4,7 @@ import NIO
 ///
 ///     builder.run()
 ///
-public protocol SQLQueryBuilder: class {
+public protocol SQLQueryBuilder: AnyObject {
     /// Query being built.
     var query: SQLExpression { get }
     


### PR DESCRIPTION
Fixes the following warnings now produced by the Swift 5.4 compiler:

```
warning: using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead
public protocol SQLPredicateBuilder: class {
                                     ^~~~~
                                     AnyObject
```