### PR TITLE
Adds `@discardableResult` for building variables

### DIFF
--- a/Sources/SQLKit/Builders/SQLAlterEnumBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLAlterEnumBuilder.swift
@@ -19,11 +19,13 @@ public final class SQLAlterEnumBuilder: SQLQueryBuilder {
         self.database = database
         self.alterEnum = .init(name: name, value: nil)
     }
-
+    
+    @discardableResult
     public func add(value: String) -> Self {
         self.add(value: SQLLiteral.string(value))
     }
-
+    
+    @discardableResult
     public func add(value: SQLExpression) -> Self {
         self.alterEnum.value = value
         return self

--- a/Sources/SQLKit/Builders/SQLAlterTableBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLAlterTableBuilder.swift
@@ -18,7 +18,8 @@ public final class SQLAlterTableBuilder: SQLQueryBuilder {
         self.alterTable = alterTable
         self.database = database
     }
-
+    
+    @discardableResult
     public func column(
         _ column: String,
         type dataType: SQLDataType,
@@ -30,7 +31,8 @@ public final class SQLAlterTableBuilder: SQLQueryBuilder {
             constraints: constraints
         ))
     }
-
+    
+    @discardableResult
     public func column(
         _ column: String,
         type dataType: SQLDataType,
@@ -42,7 +44,8 @@ public final class SQLAlterTableBuilder: SQLQueryBuilder {
             constraints: constraints
         ))
     }
-
+    
+    @discardableResult
     public func column(
         _ column: SQLExpression,
         type dataType: SQLExpression,
@@ -54,7 +57,8 @@ public final class SQLAlterTableBuilder: SQLQueryBuilder {
             constraints: constraints
         ))
     }
-
+    
+    @discardableResult
     public func column(
         _ column: SQLExpression,
         type dataType: SQLExpression,
@@ -66,12 +70,14 @@ public final class SQLAlterTableBuilder: SQLQueryBuilder {
             constraints: constraints
         ))
     }
-
+    
+    @discardableResult
     public func addColumn(_ columnDefinition: SQLExpression) -> Self {
         self.alterTable.addColumns.append(columnDefinition)
         return self
     }
-
+    
+    @discardableResult
     public func modifyColumn(
         _ column: String,
         type dataType: SQLDataType,
@@ -83,7 +89,8 @@ public final class SQLAlterTableBuilder: SQLQueryBuilder {
             constraints: constraints
         ))
     }
-
+    
+    @discardableResult
     public func modifyColumn(
         _ column: String,
         type dataType: SQLDataType,
@@ -95,7 +102,8 @@ public final class SQLAlterTableBuilder: SQLQueryBuilder {
             constraints: constraints
         ))
     }
-
+    
+    @discardableResult
     public func modifyColumn(
         _ column: SQLExpression,
         type dataType: SQLExpression,
@@ -107,7 +115,8 @@ public final class SQLAlterTableBuilder: SQLQueryBuilder {
             constraints: constraints
         ))
     }
-
+    
+    @discardableResult
     public func modifyColumn(
         _ column: SQLExpression,
         type dataType: SQLExpression,
@@ -119,7 +128,8 @@ public final class SQLAlterTableBuilder: SQLQueryBuilder {
             constraints: constraints
         ))
     }
-
+    
+    @discardableResult
     public func update(
         column: String,
         type dataType: SQLDataType
@@ -129,7 +139,8 @@ public final class SQLAlterTableBuilder: SQLQueryBuilder {
             dataType: dataType
         ))
     }
-
+    
+    @discardableResult
     public func update(
         column: SQLExpression,
         type dataType: SQLExpression
@@ -139,18 +150,21 @@ public final class SQLAlterTableBuilder: SQLQueryBuilder {
             dataType: dataType
         ))
     }
-
+    
+    @discardableResult
     public func modifyColumn(_ columnDefinition: SQLExpression) -> Self {
         self.alterTable.modifyColumns.append(columnDefinition)
         return self
     }
-
+    
+    @discardableResult
     public func dropColumn(
         _ column: String
     ) -> Self {
         return self.dropColumn(SQLIdentifier(column))
     }
-
+    
+    @discardableResult
     public func dropColumn(
         _ column: SQLExpression
     ) -> Self {

--- a/Sources/SQLKit/Builders/SQLCreateEnumBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLCreateEnumBuilder.swift
@@ -49,11 +49,13 @@ public final class SQLCreateEnumBuilder: SQLQueryBuilder {
         self.createEnum = .init(name: name, values: [])
         self.database = database
     }
-
+    
+    @discardableResult
     public func value(_ value: String) -> Self {
         self.value(SQLLiteral.string(value))
     }
-
+    
+    @discardableResult
     public func value(_ value: SQLExpression) -> Self {
         self.createEnum.values.append(value)
         return self

--- a/Sources/SQLKit/Builders/SQLCreateIndexBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLCreateIndexBuilder.swift
@@ -16,6 +16,7 @@ public final class SQLCreateIndexBuilder: SQLQueryBuilder {
     }
     
     /// Adds `UNIQUE` modifier to the index being created.
+    @discardableResult
     public func unique() -> Self {
         self.createIndex.modifier = SQLColumnConstraintAlgorithm.unique
         return self
@@ -28,6 +29,7 @@ public final class SQLCreateIndexBuilder: SQLQueryBuilder {
     /// - parameters:
     ///     - table: Table to create index on.
     /// - returns: `SQLCreateIndexBuilder`.
+    @discardableResult
     public func on(_ table: String) -> Self {
         return self.on(SQLIdentifier(table))
     }
@@ -39,6 +41,7 @@ public final class SQLCreateIndexBuilder: SQLQueryBuilder {
     /// - parameters:
     ///     - table: Table to create index on.
     /// - returns: `SQLCreateIndexBuilder`.
+    @discardableResult
     public func on(_ column: SQLExpression) -> Self {
         self.createIndex.table = column
         return self
@@ -51,6 +54,7 @@ public final class SQLCreateIndexBuilder: SQLQueryBuilder {
     /// - parameters:
     ///     - column: Column to create index on.
     /// - returns: `SQLCreateIndexBuilder`.
+    @discardableResult
     public func column(_ column: String) -> Self {
         return self.column(SQLIdentifier(column))
     }
@@ -62,6 +66,7 @@ public final class SQLCreateIndexBuilder: SQLQueryBuilder {
     /// - parameters:
     ///     - column: Column to create index on.
     /// - returns: `SQLCreateIndexBuilder`.
+    @discardableResult
     public func column(_ column: SQLExpression) -> Self {
         self.createIndex.columns.append(column)
         return self

--- a/Sources/SQLKit/Builders/SQLCreateTableBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLCreateTableBuilder.swift
@@ -26,7 +26,8 @@ public final class SQLCreateTableBuilder: SQLQueryBuilder {
         self.createTable = createTable
         self.database = database
     }
-
+    
+    @discardableResult
     public func column(
         _ column: String,
         type dataType: SQLDataType,
@@ -38,7 +39,8 @@ public final class SQLCreateTableBuilder: SQLQueryBuilder {
             constraints: constraints
         ))
     }
-
+    
+    @discardableResult
     public func column(
         _ column: String,
         type dataType: SQLDataType,
@@ -50,7 +52,8 @@ public final class SQLCreateTableBuilder: SQLQueryBuilder {
             constraints: constraints
         ))
     }
-
+    
+    @discardableResult
     public func column(
         _ column: SQLExpression,
         type dataType: SQLExpression,
@@ -62,7 +65,8 @@ public final class SQLCreateTableBuilder: SQLQueryBuilder {
             constraints: constraints
         ))
     }
-
+    
+    @discardableResult
     public func column(
         _ column: SQLExpression,
         type dataType: SQLExpression,
@@ -74,19 +78,22 @@ public final class SQLCreateTableBuilder: SQLQueryBuilder {
             constraints: constraints
         ))
     }
-
+    
+    @discardableResult
     public func column(_ columnDefinition: SQLExpression) -> Self {
         self.columns.append(columnDefinition)
         return self
     }
     
     /// Sugar for `definitions.forEach { builder.column($0) }`
+    @discardableResult
     public func column(definitions: [SQLColumnDefinition]) -> SQLCreateTableBuilder {
         self.columns.append(contentsOf: definitions)
         return self
     }
 
     /// If the "TEMP" or "TEMPORARY" keyword occurs between the "CREATE" and "TABLE" then the new table is created in the temp database.
+    @discardableResult
     public func temporary() -> Self {
         createTable.temporary = true
         return self
@@ -97,6 +104,7 @@ public final class SQLCreateTableBuilder: SQLQueryBuilder {
     /// of the same name already exists, the CREATE TABLE command simply has no effect (and no error message is returned). An
     /// error is still returned if the table cannot be created because of an existing index, even if the "IF NOT EXISTS" clause is
     /// specified.
+    @discardableResult
     public func ifNotExists() -> Self {
         createTable.ifNotExists = true
         return self
@@ -111,6 +119,7 @@ extension SQLCreateTableBuilder {
     /// - parameters:
     ///     - columns: One or more  columns of the table currently being built to make into a Primary Key.
     ///     - constraintName: An optional name to give the constraint.
+    @discardableResult
     public func primaryKey(_ columns: String..., named constraintName: String? = nil) -> Self {
         return primaryKey(columns, named: constraintName)
     }
@@ -120,6 +129,7 @@ extension SQLCreateTableBuilder {
     /// - parameters:
     ///     - columns: One or more  columns of the table currently being built to make into a Primary Key.
     ///     - constraintName: An optional name to give the constraint.
+    @discardableResult
     public func primaryKey(_ columns: [String], named constraintName: String? = nil) -> Self {
         return primaryKey(
             columns.map(SQLIdentifier.init(_:)),
@@ -132,6 +142,7 @@ extension SQLCreateTableBuilder {
     /// - parameters:
     ///     - columns: One or more  columns of the table currently being built to make into a Primary Key.
     ///     - constraintName: An optional name to give the constraint.
+    @discardableResult
     public func primaryKey(_ columns: [SQLExpression], named constraintName: SQLExpression? = nil) -> Self {
         createTable.tableConstraints.append(
             SQLConstraint(
@@ -147,6 +158,7 @@ extension SQLCreateTableBuilder {
     /// - parameters:
     ///     - columns: One or more  columns of the table currently being built to make into a UNIQUE constraint.
     ///     - constraintName: An optional name to give the constraint.
+    @discardableResult
     public func unique(_ columns: String..., named constraintName: String? = nil) -> Self {
         return unique(columns, named: constraintName)
     }
@@ -156,6 +168,7 @@ extension SQLCreateTableBuilder {
     /// - parameters:
     ///     - columns: One or more  columns of the table currently being built to make into a UNIQUE constraint.
     ///     - constraintName: An optional name to give the constraint.
+    @discardableResult
     public func unique(_ columns: [String], named constraintName: String? = nil) -> Self {
         return unique(
             columns.map(SQLIdentifier.init(_:)),
@@ -168,6 +181,7 @@ extension SQLCreateTableBuilder {
     /// - parameters:
     ///     - columns: One or more  columns of the table currently being built to make into a UNIQUE constraint.
     ///     - constraintName: An optional name to give the constraint.
+    @discardableResult
     public func unique(_ columns: [SQLExpression], named constraintName: SQLExpression? = nil) -> Self {
         createTable.tableConstraints.append(
             SQLConstraint(
@@ -183,6 +197,7 @@ extension SQLCreateTableBuilder {
     /// - parameters:
     ///     - expression: A check constraint expression.
     ///     - constraintName: An optional name to give the constraint.
+    @discardableResult
     public func check(_ expression: SQLExpression, named constraintName: String? = nil) -> Self {
         return self.check(
             expression,
@@ -195,6 +210,7 @@ extension SQLCreateTableBuilder {
     /// - parameters:
     ///     - expression: A check constraint expression.
     ///     - constraintName: An optional name to give the constraint.
+    @discardableResult
     public func check(_ expression: SQLExpression, named constraintName: SQLExpression? = nil) -> Self {
         createTable.tableConstraints.append(
             SQLConstraint(
@@ -214,6 +230,7 @@ extension SQLCreateTableBuilder {
     ///     - onDelete: Optional foreign key action to perform on delete.
     ///     - onUpdate: Optional foreign key action to perform on update.
     ///     - constraintName: An optional name to give the constraint.
+    @discardableResult
     public func foreignKey(
         _ columns: [String],
         references foreignTable: String,
@@ -241,6 +258,7 @@ extension SQLCreateTableBuilder {
     ///     - onDelete: Optional foreign key action to perform on delete.
     ///     - onUpdate: Optional foreign key action to perform on update.
     ///     - constraintName: An optional name to give the constraint.
+    @discardableResult
     public func foreignKey(
         _ columns: [SQLExpression],
         references foreignTable: SQLExpression,

--- a/Sources/SQLKit/Builders/SQLCreateTriggerBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLCreateTriggerBuilder.swift
@@ -24,6 +24,7 @@ public final class SQLCreateTriggerBuilder: SQLQueryBuilder {
 
     /// Identifies whether the trigger applies to each row or each statement.
     /// - Parameter value: The option to use.
+    @discardableResult
     public func each(_ value: SQLTriggerEach) -> SQLCreateTriggerBuilder {
         createTrigger.each = value
         return self
@@ -31,12 +32,14 @@ public final class SQLCreateTriggerBuilder: SQLQueryBuilder {
 
     /// Identifies whether the trigger applies to each row or each statement.
     /// - Parameter value: The appropriate row or statement value for the language.
+    @discardableResult
     public func each(_ value: SQLExpression) -> SQLCreateTriggerBuilder {
         createTrigger.each = value
         return self
     }
 
     /// Specifies this is a constraint trigger.
+    @discardableResult
     public func isConstraint() -> SQLCreateTriggerBuilder {
         createTrigger.isConstraint = true
         return self
@@ -44,6 +47,7 @@ public final class SQLCreateTriggerBuilder: SQLQueryBuilder {
 
     /// The columns which the trigger applies to.
     /// - Parameter columns: The names of the columns.
+    @discardableResult
     public func columns(_ columns: [String]) -> SQLCreateTriggerBuilder {
         createTrigger.columns = columns.map { SQLRaw($0) }
         return self
@@ -51,6 +55,7 @@ public final class SQLCreateTriggerBuilder: SQLQueryBuilder {
 
     /// The columns which the trigger applies to.
     /// - Parameter columns: The names of the columns.
+    @discardableResult
     public func columns(_ columns: [SQLExpression]) -> SQLCreateTriggerBuilder {
         createTrigger.columns = columns
         return self
@@ -60,6 +65,7 @@ public final class SQLCreateTriggerBuilder: SQLQueryBuilder {
     /// - Parameter value: When the trigger applies.
     /// ### Note ###
     /// Only applicable to constraint triggers.
+    @discardableResult
     public func timing(_ value: SQLTriggerTiming) -> SQLCreateTriggerBuilder {
         createTrigger.timing = value
         return self
@@ -69,6 +75,7 @@ public final class SQLCreateTriggerBuilder: SQLQueryBuilder {
     /// - Parameter value: The appropriate option.
     /// ### Note ###
     /// Only applicable to constraint triggers.
+    @discardableResult
     public func timing(_ value: SQLExpression) -> SQLCreateTriggerBuilder {
         createTrigger.timing = value
         return self
@@ -76,6 +83,7 @@ public final class SQLCreateTriggerBuilder: SQLQueryBuilder {
 
     /// A Boolean expression that determines whether the trigger function will actually be executed
     /// - Parameter value: The condition
+    @discardableResult
     public func condition(_ value: String) -> SQLCreateTriggerBuilder {
         createTrigger.condition = SQLRaw(value)
         return self
@@ -83,6 +91,7 @@ public final class SQLCreateTriggerBuilder: SQLQueryBuilder {
 
     /// A Boolean expression that determines whether the trigger function will actually be executed
     /// - Parameter value: The condition
+    @discardableResult
     public func condition(_ value: SQLExpression) -> SQLCreateTriggerBuilder {
         createTrigger.condition = value
         return self
@@ -92,6 +101,7 @@ public final class SQLCreateTriggerBuilder: SQLQueryBuilder {
     /// - Parameter value: The name of the table.
     /// ### Note ###
     /// This option is used for foreign-key constraints and is not recommended for general use. This can only be specified for constraint triggers.
+    @discardableResult
     public func referencedTable(_ value: String) -> SQLCreateTriggerBuilder {
         createTrigger.referencedTable = SQLIdentifier(value)
         return self
@@ -101,6 +111,7 @@ public final class SQLCreateTriggerBuilder: SQLQueryBuilder {
     /// - Parameter value: The name of the table.
     /// ### Note ###
     /// This option is used for foreign-key constraints and is not recommended for general use. This can only be specified for constraint triggers.
+    @discardableResult
     public func referencedTable(_ value: SQLExpression) -> SQLCreateTriggerBuilder {
         createTrigger.referencedTable = value
         return self
@@ -108,6 +119,7 @@ public final class SQLCreateTriggerBuilder: SQLQueryBuilder {
 
     /// The body of the trigger for those dialects that include the body in the trigger itself.
     /// - Parameter statements: The statements for the body of the trigger.
+    @discardableResult
     public func body(_ statements: [String]) -> SQLCreateTriggerBuilder {
         createTrigger.body = statements.map { SQLRaw($0) }
         return self
@@ -115,6 +127,7 @@ public final class SQLCreateTriggerBuilder: SQLQueryBuilder {
 
     /// The body of the trigger for those dialects that include the body in the trigger itself.
     /// - Parameter statements: The statements for the body of the trigger.
+    @discardableResult
     public func body(_ statements: [SQLExpression]) -> SQLCreateTriggerBuilder {
         createTrigger.body = statements
         return self
@@ -122,6 +135,7 @@ public final class SQLCreateTriggerBuilder: SQLQueryBuilder {
 
     /// The name of the procedure the trigger will execute for dialects that don't include the body in the trigger itself.
     /// - Parameter name: The name of the procedure.
+    @discardableResult
     public func procedure(_ name: String) -> SQLCreateTriggerBuilder {
         createTrigger.procedure = SQLIdentifier(name)
         return self
@@ -129,6 +143,7 @@ public final class SQLCreateTriggerBuilder: SQLQueryBuilder {
 
     /// The name of the procedure the trigger will execute for dialects that don't include the body in the trigger itself.
     /// - Parameter name: The name of the procedure.
+    @discardableResult
     public func procedure(_ name: SQLExpression) -> SQLCreateTriggerBuilder {
         createTrigger.procedure = name
         return self
@@ -138,6 +153,7 @@ public final class SQLCreateTriggerBuilder: SQLQueryBuilder {
     /// - Parameters:
     ///   - precedence: The precedence of this trigger in relation to `otherTriggerName`
     ///   - otherTriggerName: The name of the other trigger.
+    @discardableResult
     public func order(precedence: SQLTriggerOrder, otherTriggerName: String) -> SQLCreateTriggerBuilder {
         createTrigger.order = precedence
         createTrigger.orderTriggerName = SQLIdentifier(otherTriggerName)
@@ -148,6 +164,7 @@ public final class SQLCreateTriggerBuilder: SQLQueryBuilder {
     /// - Parameters:
     ///   - precedence: The precedence of this trigger in relation to `otherTriggerName`
     ///   - otherTriggerName: The name of the other trigger.
+    @discardableResult
     public func order(precedence: SQLTriggerOrder, otherTriggerName: SQLExpression) -> SQLCreateTriggerBuilder {
         createTrigger.order = otherTriggerName
         createTrigger.orderTriggerName = otherTriggerName
@@ -158,6 +175,7 @@ public final class SQLCreateTriggerBuilder: SQLQueryBuilder {
     /// - Parameters:
     ///   - precedence: The precedence of this trigger in relation to `otherTriggerName`
     ///   - otherTriggerName: The name of the other trigger.
+    @discardableResult
     public func order(precedence: SQLExpression, otherTriggerName: SQLExpression) -> SQLCreateTriggerBuilder {
         createTrigger.order = precedence
         createTrigger.orderTriggerName = otherTriggerName

--- a/Sources/SQLKit/Builders/SQLDropEnumBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLDropEnumBuilder.swift
@@ -45,6 +45,7 @@ public final class SQLDropEnumBuilder: SQLQueryBuilder {
 
     /// The optional `IF EXISTS` clause suppresses the error that would normally
     /// result if the type does not exist.
+    @discardableResult
     public func ifExists() -> Self {
         self.dropEnum.ifExists = true
         return self
@@ -53,6 +54,7 @@ public final class SQLDropEnumBuilder: SQLQueryBuilder {
     /// The optional `CASCADE` clause drops other objects that depend on this type
     /// (such as table columns, functions, and operators), and in turn all objects
     /// that depend on those objects.
+    @discardableResult
     public func cascade() -> Self {
         self.dropEnum.cascade = true
         return self

--- a/Sources/SQLKit/Builders/SQLDropIndexBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLDropIndexBuilder.swift
@@ -23,6 +23,7 @@ public final class SQLDropIndexBuilder: SQLQueryBuilder {
 
     /// The optional `IF EXISTS` clause suppresses the error that would normally
     /// result if the index does not exist.
+    @discardableResult
     public func ifExists() -> Self {
         dropIndex.ifExists = true
         return self
@@ -31,6 +32,7 @@ public final class SQLDropIndexBuilder: SQLQueryBuilder {
     /// The drop behavior clause specifies if objects that depend on a index
     /// should also be dropped or not when the index is dropped, for databases
     /// that support this.
+    @discardableResult
     public func behavior(_ behavior: SQLDropBehavior) -> Self {
         dropIndex.behavior = behavior
         return self
@@ -38,6 +40,7 @@ public final class SQLDropIndexBuilder: SQLQueryBuilder {
 
     /// Adds a `CASCADE` clause to the `DROP INDEX` statement instructing that
     /// objects that depend on this index should also be dropped.
+    @discardableResult
     public func cascade() -> Self {
         dropIndex.behavior = SQLDropBehavior.cascade
         return self
@@ -45,6 +48,7 @@ public final class SQLDropIndexBuilder: SQLQueryBuilder {
 
     /// Adds a `RESTRICT` clause to the `DROP INDEX` statement instructing that
     /// if any objects depend on this index, the drop should be refused.
+    @discardableResult
     public func restrict() -> Self {
         dropIndex.behavior = SQLDropBehavior.restrict
         return self

--- a/Sources/SQLKit/Builders/SQLDropTableBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLDropTableBuilder.swift
@@ -23,6 +23,7 @@ public final class SQLDropTableBuilder: SQLQueryBuilder {
     
     /// The optional `IF EXISTS` clause suppresses the error that would normally
     /// result if the table does not exist.
+    @discardableResult
     public func ifExists() -> Self {
         dropTable.ifExists = true
         return self
@@ -31,6 +32,7 @@ public final class SQLDropTableBuilder: SQLQueryBuilder {
     /// The drop behavior clause specifies if objects that depend on a table
     /// should also be dropped or not when the table is dropped, for databases
     /// that support this.
+    @discardableResult
     public func behavior(_ behavior: SQLDropBehavior) -> Self {
         dropTable.behavior = behavior
         return self
@@ -38,6 +40,7 @@ public final class SQLDropTableBuilder: SQLQueryBuilder {
 
     /// Adds a `CASCADE` clause to the `DROP TABLE` statement instructing that
     /// objects that depend on this table should also be dropped.
+    @discardableResult
     public func cascade() -> Self {
         dropTable.behavior = SQLDropBehavior.cascade
         return self
@@ -45,6 +48,7 @@ public final class SQLDropTableBuilder: SQLQueryBuilder {
 
     /// Adds a `RESTRICT` clause to the `DROP TABLE` statement instructing that
     /// if any objects depend on this table, the drop should be refused.
+    @discardableResult
     public func restrict() -> Self {
         dropTable.behavior = SQLDropBehavior.restrict
         return self

--- a/Sources/SQLKit/Builders/SQLDropTriggerBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLDropTriggerBuilder.swift
@@ -32,6 +32,7 @@ public final class SQLDropTriggerBuilder: SQLQueryBuilder {
 
     /// The optional `IF EXISTS` clause suppresses the error that would normally
     /// result if the table does not exist.
+    @discardableResult
     public func ifExists() -> Self {
         dropTrigger.ifExists = true
         return self 
@@ -40,16 +41,19 @@ public final class SQLDropTriggerBuilder: SQLQueryBuilder {
     /// The optional `CASCADE` clause drops other objects that depend on this type
     /// (such as table columns, functions, and operators), and in turn all objects
     /// that depend on those objects.
+    @discardableResult
     public func cascade() -> Self {
         dropTrigger.cascade = true
         return self
     }
-
+    
+    @discardableResult
     public func table(_ name: String) -> Self {
         dropTrigger.table = SQLIdentifier(name)
         return self
     }
-
+    
+    @discardableResult
     public func table(_ name: SQLExpression) -> Self {
         dropTrigger.table = name
         return self

--- a/Sources/SQLKit/Builders/SQLInsertBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLInsertBuilder.swift
@@ -36,11 +36,13 @@ public final class SQLInsertBuilder: SQLQueryBuilder, SQLReturningBuilder {
     /// - parameters:
     ///     - value: `Encodable` value to insert.
     /// - returns: Self for chaining.
+    @discardableResult
     public func model<E>(_ model: E, prefix: String? = nil, keyEncodingStrategy: SQLQueryEncoder.KeyEncodingStrategy = .useDefaultKeys, nilEncodingStrategy: SQLQueryEncoder.NilEncodingStrategy = .default) throws -> Self
         where E: Encodable {
         return try models([model], prefix: prefix, keyEncodingStrategy: keyEncodingStrategy, nilEncodingStrategy: nilEncodingStrategy)
     }
-
+    
+    @discardableResult
     public func models<E>(_ models: [E], prefix: String? = nil, keyEncodingStrategy: SQLQueryEncoder.KeyEncodingStrategy = .useDefaultKeys, nilEncodingStrategy: SQLQueryEncoder.NilEncodingStrategy = .default) throws -> Self where E: Encodable {
         var encoder = SQLQueryEncoder()
         encoder.keyEncodingStrategy = keyEncodingStrategy
@@ -63,43 +65,51 @@ public final class SQLInsertBuilder: SQLQueryBuilder, SQLReturningBuilder {
         return self
     }
     
+    @discardableResult
     public func columns(_ columns: String...) -> Self {
         self.insert.columns = columns.map(SQLIdentifier.init(_:))
         return self
     }
     
+    @discardableResult
     public func columns(_ columns: [String]) -> Self {
         self.insert.columns = columns.map(SQLIdentifier.init(_:))
         return self
     }
-
+    
+    @discardableResult
     public func columns(_ columns: SQLExpression...) -> Self {
         self.insert.columns = columns
         return self
     }
     
+    @discardableResult
     public func columns(_ columns: [SQLExpression]) -> Self {
         self.insert.columns = columns
         return self
     }
     
+    @discardableResult
     public func values(_ values: Encodable...) -> Self {
         let row: [SQLExpression] = values.map(SQLBind.init)
         self.insert.values.append(row)
         return self
     }
     
+    @discardableResult
     public func values(_ values: [Encodable]) -> Self {
         let row: [SQLExpression] = values.map(SQLBind.init)
         self.insert.values.append(row)
         return self
     }
     
+    @discardableResult
     public func values(_ values: SQLExpression...) -> Self {
         self.insert.values.append(values)
         return self
     }
-
+    
+    @discardableResult
     public func values(_ values: [SQLExpression]) -> Self {
         self.insert.values.append(values)
         return self

--- a/Sources/SQLKit/Builders/SQLJoinBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLJoinBuilder.swift
@@ -15,6 +15,7 @@ extension SQLJoinBuilder {
     ///   - table: The name of the table to join.
     ///   - method: The join method to use.
     ///   - expression: A string containing a join condition.
+    @discardableResult
     public func join(_ table: String, method: SQLJoinMethod = .inner, on expression: String) -> Self {
          self.join(SQLIdentifier(table), method: method, on: SQLRaw(expression))
     }
@@ -29,6 +30,7 @@ extension SQLJoinBuilder {
     ///   - table: An expression identifying the table to join.
     ///   - method: An expression providing the join method to use.
     ///   - expression: An expression used as the join condition.
+    @discardableResult
     public func join(_ table: SQLExpression, method: SQLExpression = SQLJoinMethod.inner, on expression: SQLExpression) -> Self {
         self.joins.append(SQLJoin(method: method, table: table, expression: expression))
         return self
@@ -47,6 +49,7 @@ extension SQLJoinBuilder {
     ///   - left: The left side of a binary expression used as a join condition.
     ///   - op: The operator in a binary expression used as a join condition.
     ///   - right: The right side of a binary expression used as a join condition.
+    @discardableResult
     public func join(
         _ table: SQLExpression,
         method: SQLExpression = SQLJoinMethod.inner,
@@ -69,6 +72,7 @@ extension SQLJoinBuilder {
     ///   - method: An expression providing the join method to use.
     ///   - column: An expression giving a list of columns to match between
     ///             the joined tables.
+    @discardableResult
     public func join(_ table: SQLExpression, method: SQLExpression = SQLJoinMethod.inner, using columns: SQLExpression) -> Self {
         // TODO TODO TODO: Figure out a nice way to make `SQLJoin` aware of the
         // `USING()` syntax; this method is hacky and doesn't respect

--- a/Sources/SQLKit/Builders/SQLPredicateBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLPredicateBuilder.swift
@@ -25,6 +25,7 @@ extension SQLPredicateBuilder {
     ///     - lhs: Left-hand side column name.
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Right-hand side column name.
+    @discardableResult
     public func `where`(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, column rhs: SQLIdentifier) -> Self {
         self.where(lhs, op, rhs)
     }
@@ -42,6 +43,7 @@ extension SQLPredicateBuilder {
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Encodable value.
     /// - returns: Self for chaining.
+    @discardableResult
     public func `where`<E>(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: E) -> Self
         where E: Encodable
     {
@@ -61,6 +63,7 @@ extension SQLPredicateBuilder {
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Encodable value.
     /// - returns: Self for chaining.
+    @discardableResult
     public func `where`<E>(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: [E]) -> Self
         where E: Encodable
     {
@@ -75,6 +78,7 @@ extension SQLPredicateBuilder {
     ///     - lhs: Left-hand side column name.
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Right-hand side expression.
+    @discardableResult
     public func `where`(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
         self.where(lhs, op as SQLExpression, rhs)
     }
@@ -87,6 +91,7 @@ extension SQLPredicateBuilder {
     ///     - lhs: Left-hand side column name.
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Right-hand side expression.
+    @discardableResult
     public func `where`(_ lhs: SQLExpression, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
         self.where(lhs, op as SQLExpression, rhs)
     }
@@ -101,6 +106,7 @@ extension SQLPredicateBuilder {
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Right-hand side expression.
     /// - returns: Self for chaining.
+    @discardableResult
     public func `where`(_ lhs: SQLExpression, _ op: SQLExpression, _ rhs: SQLExpression) -> Self {
         self.where(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
@@ -111,6 +117,7 @@ extension SQLPredicateBuilder {
     ///
     /// - parameters:
     ///     - expression: Expression to be added to the predicate.
+    @discardableResult
     public func `where`(_ expression: SQLExpression) -> Self {
         if let existing = self.predicate {
             self.predicate = SQLBinaryExpression(
@@ -132,6 +139,7 @@ extension SQLPredicateBuilder {
     ///     - lhs: Left-hand side column name.
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Right-hand side expression.
+    @discardableResult
     public func orWhere(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
         return self.orWhere(SQLIdentifier(lhs), op, rhs)
     }
@@ -145,6 +153,7 @@ extension SQLPredicateBuilder {
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Right-hand side expression.
     /// - returns: Self for chaining.
+    @discardableResult
     public func orWhere(_ lhs: SQLExpression, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
         return self.orWhere(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
@@ -159,6 +168,7 @@ extension SQLPredicateBuilder {
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Right-hand side expression.
     /// - returns: Self for chaining.
+    @discardableResult
     public func orWhere(_ lhs: SQLExpression, _ op: SQLExpression, _ rhs: SQLExpression) -> Self {
         return self.orWhere(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
@@ -169,6 +179,7 @@ extension SQLPredicateBuilder {
     ///
     /// - parameters:
     ///     - expression: Expression to be added to the predicate.
+    @discardableResult
     public func orWhere(_ expression: SQLExpression) -> Self {
         if let existing = self.predicate {
             self.predicate = SQLBinaryExpression(

--- a/Sources/SQLKit/Builders/SQLPredicateGroupBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLPredicateGroupBuilder.swift
@@ -23,6 +23,7 @@ extension SQLPredicateBuilder {
     ///
     ///     WHERE "type" = "smallRocky" AND ("name" = "Earth" OR "name" = "Mars")
     ///
+    @discardableResult
     public func `where`(group: (SQLPredicateGroupBuilder) -> (SQLPredicateGroupBuilder)) -> Self {
         let builder = SQLPredicateGroupBuilder()
         _ = group(builder)
@@ -43,6 +44,7 @@ extension SQLPredicateBuilder {
     ///
     ///     WHERE "name" = "Jupiter" OR ("name" = "Earth" AND "type" = "smallRocky")
     ///
+    @discardableResult
     public func orWhere(group: (SQLPredicateGroupBuilder) -> (SQLPredicateGroupBuilder)) -> Self {
         let builder = SQLPredicateGroupBuilder()
         _ = group(builder)

--- a/Sources/SQLKit/Builders/SQLSelectBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLSelectBuilder.swift
@@ -53,6 +53,7 @@ extension SQLSelectBuilder {
     ///     builder.distinct()
     ///
     /// - returns: Self for chaining
+    @discardableResult
     public func distinct() -> Self {
         self.select.isDistinct = true
         return self
@@ -63,6 +64,7 @@ extension SQLSelectBuilder {
     ///     builder.distinct(on: "my_collumn")
     ///
     /// - returns: Self for chaining
+    @discardableResult
     public func distinct(on columns: String...) -> Self {
         self.select.isDistinct = true
         self.select.columns = []
@@ -75,6 +77,7 @@ extension SQLSelectBuilder {
     ///     builder.distinct(on: SQLRaw("my_collumn"))
     ///
     /// - returns: Self for chaining
+    @discardableResult
     public func distinct(on columns: SQLExpression...) -> Self {
         self.select.isDistinct = true
         self.select.columns = columns
@@ -91,6 +94,7 @@ extension SQLSelectBuilder {
     /// `SQLLiteral.all`.
     ///
     /// - Parameter column: The name of the column to return, or "*" for all.
+    @discardableResult
     public func column(_ column: String) -> Self {
         if column == "*" {
             return self.column(SQLLiteral.all)
@@ -106,6 +110,7 @@ extension SQLSelectBuilder {
     /// - Parameters:
     ///   - table: The name of a table to qualify the column name.
     ///   - column: The name of the column to return.
+    @discardableResult
     public func column(table: String, column: String) -> Self {
         return self.column(SQLColumn(SQLIdentifier(column), table: SQLIdentifier(table)))
     }
@@ -114,6 +119,7 @@ extension SQLSelectBuilder {
     /// is an arbitrary expression.
     ///
     /// - Parameter expr: An expression identifying the desired data to return.
+    @discardableResult
     public func column(_ expr: SQLExpression) -> Self {
         self.select.columns.append(expr)
         return self
@@ -125,6 +131,7 @@ extension SQLSelectBuilder {
     /// `SQLLiteral.all`.
     ///
     /// - Parameter columns: The names of the columns to return.
+    @discardableResult
     public func columns(_ columns: String...) -> Self {
         return columns.reduce(self) { $0.column($1) }
     }
@@ -135,6 +142,7 @@ extension SQLSelectBuilder {
     /// `SQLLiteral.all`.
     ///
     /// - Parameter columns: The names of the columns to return.
+    @discardableResult
     public func columns(_ columns: [String]) -> Self {
         return columns.reduce(self) { $0.column($1) }
     }
@@ -144,6 +152,7 @@ extension SQLSelectBuilder {
     ///
     /// - Parameter columns: A list of expressions identifying the desired data
     ///                      to return.
+    @discardableResult
     public func columns(_ columns: SQLExpression...) -> Self {
         return self.columns(columns)
     }
@@ -153,6 +162,7 @@ extension SQLSelectBuilder {
     ///
     /// - Parameter columns: A list of expressions identifying the desired data
     ///                      to return.
+    @discardableResult
     public func columns(_ columns: [SQLExpression]) -> Self {
         return columns.reduce(self) { $0.column($1) }
     }
@@ -167,6 +177,7 @@ extension SQLSelectBuilder {
     /// be a valid SQL identifier.
     ///
     /// - Parameter table: The name of the table to use.
+    @discardableResult
     public func from(_ table: String) -> Self {
         return self.from(SQLIdentifier(table))
     }
@@ -176,6 +187,7 @@ extension SQLSelectBuilder {
     ///
     /// - Parameters:
     ///   - table: An expression identifying the table to use.
+    @discardableResult
     public func from(_ table: SQLExpression) -> Self {
         self.select.tables.append(table)
         return self
@@ -189,6 +201,7 @@ extension SQLSelectBuilder {
     /// - Parameters:
     ///   - table: The name of the table to use.
     ///   - alias: The alias to use for the table.
+    @discardableResult
     public func from(_ table: String, as alias: String) -> Self {
         return self.from(SQLIdentifier(table), as: SQLIdentifier(alias))
     }
@@ -200,6 +213,7 @@ extension SQLSelectBuilder {
     /// - Parameters:
     ///   - table: An expression identifying the table to use.
     ///   - alias: An expression providing the alias to use for the table.
+    @discardableResult
     public func from(_ table: SQLExpression, as alias: SQLExpression) -> Self {
         return self.from(SQLAlias(table, as: alias))
     }
@@ -222,6 +236,7 @@ extension SQLSelectBuilder {
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Right-hand side column name.
     /// - returns: Self for chaining.
+    @discardableResult
     public func having(_ lhs: String, _ op: SQLBinaryOperator, column rhs: String) -> Self {
         return self.having(SQLIdentifier(lhs), op, SQLIdentifier(rhs))
     }
@@ -239,6 +254,7 @@ extension SQLSelectBuilder {
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Encodable value.
     /// - returns: Self for chaining.
+    @discardableResult
     public func having(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: Encodable) -> Self {
         return self.having(SQLIdentifier(lhs), op, SQLBind(rhs))
     }
@@ -252,6 +268,7 @@ extension SQLSelectBuilder {
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Right-hand side expression.
     /// - returns: Self for chaining.
+    @discardableResult
     public func having(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
         return self.having(SQLIdentifier(lhs), op, rhs)
     }
@@ -265,6 +282,7 @@ extension SQLSelectBuilder {
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Right-hand side expression.
     /// - returns: Self for chaining.
+    @discardableResult
     public func having(_ lhs: SQLExpression, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
         return self.having(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
@@ -279,6 +297,7 @@ extension SQLSelectBuilder {
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Right-hand side expression.
     /// - returns: Self for chaining.
+    @discardableResult
     public func having(_ lhs: SQLExpression, _ op: SQLExpression, _ rhs: SQLExpression) -> Self {
         return self.having(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
@@ -289,6 +308,7 @@ extension SQLSelectBuilder {
     ///
     /// - parameters:
     ///     - expression: Expression to be added to the predicate.
+    @discardableResult
     public func having(_ expression: SQLExpression) -> Self {
         if let existing = self.select.having {
             self.select.having = SQLBinaryExpression(
@@ -311,6 +331,7 @@ extension SQLSelectBuilder {
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Right-hand side expression.
     /// - returns: Self for chaining.
+    @discardableResult
     public func orHaving(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
         return self.orHaving(SQLIdentifier(lhs), op, rhs)
     }
@@ -324,6 +345,7 @@ extension SQLSelectBuilder {
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Right-hand side expression.
     /// - returns: Self for chaining.
+    @discardableResult
     public func orHaving(_ lhs: SQLExpression, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
         return self.orHaving(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
@@ -338,6 +360,7 @@ extension SQLSelectBuilder {
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Right-hand side expression.
     /// - returns: Self for chaining.
+    @discardableResult
     public func orHaving(_ lhs: SQLExpression, _ op: SQLExpression, _ rhs: SQLExpression) -> Self {
         return self.orHaving(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
@@ -348,6 +371,7 @@ extension SQLSelectBuilder {
     ///
     /// - parameters:
     ///     - expression: Expression to be added to the predicate.
+    @discardableResult
     public func orHaving(_ expression: SQLExpression) -> Self {
         if let existing = self.select.having {
             self.select.having = SQLBinaryExpression(
@@ -373,6 +397,7 @@ extension SQLSelectBuilder {
     ///     - max: Optional maximum limit.
     ///            If `nil`, existing limit will be removed.
     /// - returns: Self for chaining.
+    @discardableResult
     public func limit(_ max: Int?) -> Self {
         self.select.limit = max
         return self
@@ -386,6 +411,7 @@ extension SQLSelectBuilder {
     ///     - max: Optional offset.
     ///            If `nil`, existing offset will be removed.
     /// - returns: Self for chaining.
+    @discardableResult
     public func offset(_ n: Int?) -> Self {
         self.select.offset = n
         return self
@@ -400,6 +426,7 @@ extension SQLSelectBuilder {
     /// - parameters:
     ///     - expression: `SQLExpression` to group by.
     /// - returns: Self for chaining.
+    @discardableResult
     public func groupBy(_ column: String) -> Self {
         return self.groupBy(SQLColumn(column))
     }
@@ -409,6 +436,7 @@ extension SQLSelectBuilder {
     /// - parameters:
     ///     - expression: `SQLExpression` to group by.
     /// - returns: Self for chaining.
+    @discardableResult
     public func groupBy(_ expression: SQLExpression) -> Self {
         self.select.groupBy.append(expression)
         return self
@@ -419,6 +447,7 @@ extension SQLSelectBuilder {
     /// - parameters:
     ///     - expression: `SQLExpression` to order by.
     /// - returns: Self for chaining.
+    @discardableResult
     public func orderBy(_ column: String, _ direction: SQLDirection = .ascending) -> Self {
         return self.orderBy(SQLColumn(column), direction)
     }
@@ -429,6 +458,7 @@ extension SQLSelectBuilder {
     /// - parameters:
     ///     - expression: `SQLExpression` to order by.
     /// - returns: Self for chaining.
+    @discardableResult
     public func orderBy(_ expression: SQLExpression, _ direction: SQLExpression) -> Self {
         return self.orderBy(SQLOrderBy(expression: expression, direction: direction))
     }
@@ -438,6 +468,7 @@ extension SQLSelectBuilder {
     /// - parameters:
     ///     - expression: `SQLExpression` to order by.
     /// - returns: Self for chaining.
+    @discardableResult
     public func orderBy(_ expression: SQLExpression) -> Self {
         select.orderBy.append(expression)
         return self
@@ -459,6 +490,7 @@ extension SQLSelectBuilder {
     /// - parameters:
     ///     - lockingClause: Locking clause type.
     /// - returns: Self for chaining.
+    @discardableResult
     public func `for`(_ lockingClause: SQLLockingClause) -> Self {
         return self.lockingClause(lockingClause)
     }
@@ -477,6 +509,7 @@ extension SQLSelectBuilder {
     /// - parameters:
     ///     - lockingClause: Locking clause type.
     /// - returns: Self for chaining.
+    @discardableResult
     public func lockingClause(_ lockingClause: SQLExpression) -> Self {
         self.select.lockingClause = lockingClause
         return self

--- a/Sources/SQLKit/Builders/SQLUpdateBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLUpdateBuilder.swift
@@ -31,7 +31,8 @@ public final class SQLUpdateBuilder: SQLQueryBuilder, SQLPredicateBuilder, SQLRe
         self.update = update
         self.database = database
     }
-
+    
+    @discardableResult
     public func set<E>(model: E) throws -> Self where E: Encodable {
         let row = try SQLQueryEncoder().encode(model)
         row.forEach { column, value in
@@ -41,11 +42,13 @@ public final class SQLUpdateBuilder: SQLQueryBuilder, SQLPredicateBuilder, SQLRe
     }
     
     /// Sets a column (specified by an identifier) to an expression.
+    @discardableResult
     public func set(_ column: String, to bind: Encodable) -> Self {
         return self.set(SQLIdentifier(column), to: SQLBind(bind))
     }
     
     /// Sets a column (specified by an identifier) to an expression.
+    @discardableResult
     public func set(_ column: SQLExpression, to value: SQLExpression) -> Self {
         let binary = SQLBinaryExpression(left: column, op: SQLBinaryOperator.equal, right: value)
         update.values.append(binary)


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

This allows users to assign the builder object to a variable and append directly to it without encountering `Result of call to '___' is unused` warnings. For example, the code below will not generate a warning:

```
let select = db.sql().select().columns("*").from("table1")
if shouldFilter {
     select.where("col1", .equal, 5)
}
let result = select.all()
```

Previously, the line within the if statement would have a `Result of call to 'where' is unused`. To clear the warning, the line would have needed an assignment like:

```
    _ = select.where("col1", .equal, 5)
```

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
