### PR TITLE
Fix raw interpolation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ The `raw(_:)` method allows for passing custom SQL query strings with support fo
 
 ```swift
 let table = "planets"
-let planets = try db.raw("SELECT * FROM \(table) WHERE name = \(bind: planet)")
+let planets = try db.raw("SELECT * FROM \(raw: table) WHERE name = \(bind: planet)")
     .all().wait()
 ```
 


### PR DESCRIPTION
Hi,

I believe the readme documentation is using the deprecated string interpolation in the raw example.
This should fix it.
