### PR TITLE
Adds '*' support for table-qualified column select

### DIFF
--- a/Sources/SQLKit/Builders/SQLSelectBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLSelectBuilder.swift
@@ -110,9 +110,17 @@ extension SQLSelectBuilder {
     /// - Parameters:
     ///   - table: The name of a table to qualify the column name.
     ///   - column: The name of the column to return.
+    ///   The string "*" (a single asterisk) is recognized and replaced by
+    ///   `SQLLiteral.all`.
     @discardableResult
     public func column(table: String, column: String) -> Self {
-        return self.column(SQLColumn(SQLIdentifier(column), table: SQLIdentifier(table)))
+        let columnExpr: SQLExpression
+        if column == "*" {
+            columnExpr = SQLLiteral.all
+        } else {
+            columnExpr = SQLIdentifier(column)
+        }
+        return self.column(SQLColumn(columnExpr, table: SQLIdentifier(table)))
     }
     
     /// Specify a column to be part of the result set of the query. The column

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -22,6 +22,14 @@ final class SQLKitTests: XCTestCase {
             .run().wait()
         XCTAssertEqual(db.results[0], "SELECT * FROM `planets` WHERE `name` IN (?, ?)")
     }
+    
+    func testSelect_tableAllCols() throws {
+        try db.select().column(table: "planets", column: "*")
+            .from("planets")
+            .where("name", .in, ["Earth", "Mars"])
+            .run().wait()
+        XCTAssertEqual(db.results[0], "SELECT `planets`.* FROM `planets` WHERE `name` IN (?, ?)")
+    }
 
     func testSelect_withoutFrom() throws {
         try db.select()


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

This adds '*' support to table-qualified columns in selects that mirrors the non-table-qualified column selects. This is mainly a convenience.

For example, before this PR `sql.select().column(table: "table", column: "*")` would resolve to ```SELECT `table`.`*` ```, where '*' was an identifier which was invalid in most cases. Now it will resolve to ```SELECT `table`.* ```

Previously to make this query work, it would have to be `sql.select().column(SQLColumn(SQLLiteral.all, table: SQLIdentifier("table"))`, which is kind of cumbersome.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
