### PR TITLE
Add support for UNION queries

### DIFF
--- a/Sources/SQLKit/Builders/SQLUnionBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLUnionBuilder.swift
@@ -7,19 +7,15 @@ public final class SQLUnionBuilder: SQLQueryBuilder {
     public var database: SQLDatabase
 
     public init(on database: SQLDatabase,
-                _ args: [SQLSelectBuilder],
-                all: Bool = false) {
-        self.union = .init(args.map(\.select), all: all)
+                all: Bool = false,
+                _ args: [SQLSelectBuilder]) {
+        self.union = .init(all: all, args.map(\.select))
         self.database = database
     }
 }
 
 extension SQLDatabase {
-    public func union(_ args: SQLSelectBuilder...) -> SQLUnionBuilder {
-        SQLUnionBuilder(on: self, args)
-    }
-
-    public func unionAll(_ args: SQLSelectBuilder...) -> SQLUnionBuilder {
-        SQLUnionBuilder(on: self, args, all: true)
+    public func union(all: Bool = false, _ args: SQLSelectBuilder...) -> SQLUnionBuilder {
+        SQLUnionBuilder(on: self, all: all, args)
     }
 }

--- a/Sources/SQLKit/Builders/SQLUnionBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLUnionBuilder.swift
@@ -1,25 +1,42 @@
 public final class SQLUnionBuilder: SQLQueryBuilder {
-    public var query: SQLExpression {
-        return self.union
-    }
+    public var query: SQLExpression { self.union }
 
     public var union: SQLUnion
     public var database: SQLDatabase
 
-    public init(on database: SQLDatabase,
-                _ args: [SQLSelectBuilder],
-                all: Bool = false) {
-        self.union = .init(args.map(\.select), all: all)
+    public init(on database: SQLDatabase, initialQuery: SQLSelect) {
+        self.union = .init(initialQuery: initialQuery)
         self.database = database
     }
+
+   public func union(distinct query: SQLSelect) -> Self {
+       self.union.add(query, all: false)
+       return self
+   }
+
+   public func union(all query: SQLSelect) -> Self {
+       self.union.add(query, all: true)
+       return self
+   }
 }
 
 extension SQLDatabase {
-    public func union(_ args: SQLSelectBuilder...) -> SQLUnionBuilder {
-        SQLUnionBuilder(on: self, args)
+    public func union(_ predicate: (SQLSelectBuilder) -> SQLSelectBuilder) -> SQLUnionBuilder {
+        return SQLUnionBuilder(on: self, initialQuery: predicate(.init(on: self)).select)
+    }
+}
+
+extension SQLUnionBuilder {
+    public func union(distinct predicate: (SQLSelectBuilder) -> SQLSelectBuilder) -> Self {
+        return self.union(distinct: predicate(.init(on: self.database)).select)
     }
 
-    public func union(all args: SQLSelectBuilder...) -> SQLUnionBuilder {
-        SQLUnionBuilder(on: self, args, all: true)
+    /// Alias the `distinct` variant so it acts as the "default".
+    public func union(_ predicate: (SQLSelectBuilder) -> SQLSelectBuilder) -> Self {
+        return self.union(distinct: predicate)
+    }
+
+    public func union(all predicate: (SQLSelectBuilder) -> SQLSelectBuilder) -> Self {
+        return self.union(all: predicate(.init(on: self.database)).select)
     }
 }

--- a/Sources/SQLKit/Builders/SQLUnionBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLUnionBuilder.swift
@@ -40,3 +40,21 @@ extension SQLUnionBuilder {
         return self.union(all: predicate(.init(on: self.database)).select)
     }
 }
+
+extension SQLSelectBuilder {
+    public func union(distinct predicate: (SQLSelectBuilder) -> SQLSelectBuilder) -> SQLUnionBuilder {
+        return SQLUnionBuilder(on: self.database, initialQuery: self.select)
+            .union(distinct: predicate(.init(on: self.database)).select)
+    }
+
+    /// Alias the `distinct` variant so it acts as the "default".
+    public func union(_ predicate: (SQLSelectBuilder) -> SQLSelectBuilder) -> SQLUnionBuilder {
+        return SQLUnionBuilder(on: self.database, initialQuery: self.select)
+            .union(distinct: predicate(.init(on: self.database)).select)
+    }
+
+    public func union(all predicate: (SQLSelectBuilder) -> SQLSelectBuilder) -> SQLUnionBuilder {
+        return SQLUnionBuilder(on: self.database, initialQuery: self.select)
+            .union(all: predicate(.init(on: self.database)).select)
+    }
+}

--- a/Sources/SQLKit/Builders/SQLUnionBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLUnionBuilder.swift
@@ -7,15 +7,19 @@ public final class SQLUnionBuilder: SQLQueryBuilder {
     public var database: SQLDatabase
 
     public init(on database: SQLDatabase,
-                all: Bool = false,
-                _ args: [SQLSelectBuilder]) {
-        self.union = .init(all: all, args.map(\.select))
+                _ args: [SQLSelectBuilder],
+                all: Bool = false) {
+        self.union = .init(args.map(\.select), all: all)
         self.database = database
     }
 }
 
 extension SQLDatabase {
-    public func union(all: Bool = false, _ args: SQLSelectBuilder...) -> SQLUnionBuilder {
-        SQLUnionBuilder(on: self, all: all, args)
+    public func union(_ args: SQLSelectBuilder...) -> SQLUnionBuilder {
+        SQLUnionBuilder(on: self, args)
+    }
+
+    public func union(all args: SQLSelectBuilder...) -> SQLUnionBuilder {
+        SQLUnionBuilder(on: self, args, all: true)
     }
 }

--- a/Sources/SQLKit/Builders/SQLUnionBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLUnionBuilder.swift
@@ -1,0 +1,19 @@
+public final class SQLUnionBuilder: SQLQueryBuilder {
+    public var query: SQLExpression {
+        return self.union
+    }
+
+    public var union: SQLUnion
+    public var database: SQLDatabase
+
+    public init(on database: SQLDatabase, _ args: [SQLSelectBuilder]) {
+        self.union = .init(args.map { $0.select })
+        self.database = database
+    }
+}
+
+extension SQLDatabase {
+    public func union(_ args: SQLSelectBuilder...) -> SQLUnionBuilder {
+        SQLUnionBuilder(on: self, args)
+    }
+}

--- a/Sources/SQLKit/Builders/SQLUnionBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLUnionBuilder.swift
@@ -9,7 +9,7 @@ public final class SQLUnionBuilder: SQLQueryBuilder {
     public init(on database: SQLDatabase,
                 _ args: [SQLSelectBuilder],
                 all: Bool = false) {
-        self.union = .init(args.map { $0.select }, all: all)
+        self.union = .init(args.map(\.select), all: all)
         self.database = database
     }
 }

--- a/Sources/SQLKit/Builders/SQLUnionBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLUnionBuilder.swift
@@ -6,8 +6,10 @@ public final class SQLUnionBuilder: SQLQueryBuilder {
     public var union: SQLUnion
     public var database: SQLDatabase
 
-    public init(on database: SQLDatabase, _ args: [SQLSelectBuilder]) {
-        self.union = .init(args.map { $0.select })
+    public init(on database: SQLDatabase,
+                _ args: [SQLSelectBuilder],
+                all: Bool = false) {
+        self.union = .init(args.map { $0.select }, all: all)
         self.database = database
     }
 }
@@ -15,5 +17,9 @@ public final class SQLUnionBuilder: SQLQueryBuilder {
 extension SQLDatabase {
     public func union(_ args: SQLSelectBuilder...) -> SQLUnionBuilder {
         SQLUnionBuilder(on: self, args)
+    }
+
+    public func unionAll(_ args: SQLSelectBuilder...) -> SQLUnionBuilder {
+        SQLUnionBuilder(on: self, args, all: true)
     }
 }

--- a/Sources/SQLKit/Query/SQLUnion.swift
+++ b/Sources/SQLKit/Query/SQLUnion.swift
@@ -13,18 +13,13 @@ public struct SQLUnion: SQLExpression {
     }
 
     public func serialize(to serializer: inout SQLSerializer) {
-        self.args
-            .map { [SQLGroupExpression($0)] }
-            .joined([SQLUnionJoiner(all: self.all)])
-            .forEach { $0.serialize(to: &serializer) }
-    }
-}
-
-fileprivate struct SQLUnionJoiner: SQLExpression {
-    let all: Bool
-    
-    func serialize(to serializer: inout SQLSerializer) {
-        serializer.write("UNION\(self.all ? " ALL" : "") ")
+        let groups = self.args.map(SQLGroupExpression.init)
+        guard let first = groups.first else { return }
+        first.serialize(to: &serializer)
+        for arg in groups.dropFirst() {
+            serializer.write(all ? " UNION ALL " : " UNION ")
+            arg.serialize(to: &serializer)
+        }
     }
 }
 

--- a/Sources/SQLKit/Query/SQLUnion.swift
+++ b/Sources/SQLKit/Query/SQLUnion.swift
@@ -13,13 +13,22 @@ public struct SQLUnion: SQLExpression {
     }
 
     public func serialize(to serializer: inout SQLSerializer) {
-        let groups = self.args.map(SQLGroupExpression.init)
-        guard let first = groups.first else { return }
-        first.serialize(to: &serializer)
-        for arg in groups.dropFirst() {
-            serializer.write(all ? " UNION ALL " : " UNION ")
-            arg.serialize(to: &serializer)
-        }
+        self.args
+            .map { [SQLGroupExpression($0)] }
+            .joined(separator: [SQLUnionJoiner(all: self.all)])
+            .forEach { (item: SQLExpression) in item.serialize(to: &serializer) }
+    }
+}
+
+public struct SQLUnionJoiner: SQLExpression {
+    public var all: Bool
+    
+    public init(all: Bool) {
+        self.all = all
+    }
+    
+    public func serialize(to serializer: inout SQLSerializer) {
+        serializer.write(" UNION\(self.all ? " ALL" : "") ")
     }
 }
 

--- a/Sources/SQLKit/Query/SQLUnion.swift
+++ b/Sources/SQLKit/Query/SQLUnion.swift
@@ -7,18 +7,24 @@ public struct SQLUnion: SQLExpression {
     }
 
     public init(_ args: [SQLExpression], all: Bool = false) {
+        precondition(!args.isEmpty, "Empty SQLUnions are not valid.") 
         self.args = args
         self.all = all
     }
 
     public func serialize(to serializer: inout SQLSerializer) {
-        let groups = args.map(SQLGroupExpression.init)
-        guard let first = groups.first else { return }
-        first.serialize(to: &serializer)
-        for arg in groups.dropFirst() {
-            serializer.write(all ? " UNION ALL " : " UNION ")
-            arg.serialize(to: &serializer)
-        }
+        self.args
+            .map { [SQLGroupExpression($0)] }
+            .joined([SQLUnionJoiner(all: self.all)])
+            .forEach { $0.serialize(to: &serializer) }
+    }
+}
+
+fileprivate struct SQLUnionJoiner: SQLExpression {
+    let all: Bool
+    
+    func serialize(to serializer: inout SQLSerializer) {
+        serializer.write("UNION\(self.all ? " ALL" : "") ")
     }
 }
 

--- a/Sources/SQLKit/Query/SQLUnion.swift
+++ b/Sources/SQLKit/Query/SQLUnion.swift
@@ -16,11 +16,7 @@ public struct SQLUnion: SQLExpression {
         guard let first = groups.first else { return }
         first.serialize(to: &serializer)
         for arg in groups.dropFirst() {
-            if all {
-                serializer.write(" UNION ALL ")
-            } else {
-                serializer.write(" UNION ")
-            }
+            serializer.write(all ? " UNION ALL " : " UNION ")
             arg.serialize(to: &serializer)
         }
     }

--- a/Sources/SQLKit/Query/SQLUnion.swift
+++ b/Sources/SQLKit/Query/SQLUnion.swift
@@ -2,13 +2,13 @@ public struct SQLUnion: SQLExpression {
     public let args: [SQLExpression]
     public let all: Bool
 
-    public init(all: Bool = false, _ args: SQLExpression...) {
-        self.init(all: all, args)
+    public init(_ args: SQLExpression..., all: Bool = false) {
+        self.init(args, all: all)
     }
 
-    public init(all: Bool = false, _ args: [SQLExpression]) {
-        self.all = all
+    public init(_ args: [SQLExpression], all: Bool = false) {
         self.args = args
+        self.all = all
     }
 
     public func serialize(to serializer: inout SQLSerializer) {

--- a/Sources/SQLKit/Query/SQLUnion.swift
+++ b/Sources/SQLKit/Query/SQLUnion.swift
@@ -1,0 +1,22 @@
+public struct SQLUnion: SQLExpression {
+    public let args: [SQLExpression]
+
+    public init(_ args: SQLExpression...) {
+        self.init(args)
+    }
+
+    public init(_ args: [SQLExpression]) {
+        self.args = args
+    }
+
+    public func serialize(to serializer: inout SQLSerializer) {
+        let args = args.map(SQLGroupExpression.init)
+        guard let first = args.first else { return }
+        first.serialize(to: &serializer)
+        for arg in args.dropFirst() {
+            serializer.write(" UNION ")
+            arg.serialize(to: &serializer)
+        }
+    }
+}
+

--- a/Sources/SQLKit/Query/SQLUnion.swift
+++ b/Sources/SQLKit/Query/SQLUnion.swift
@@ -2,13 +2,13 @@ public struct SQLUnion: SQLExpression {
     public let args: [SQLExpression]
     public let all: Bool
 
-    public init(_ args: SQLExpression..., all: Bool = false) {
-        self.init(args, all: all)
+    public init(all: Bool = false, _ args: SQLExpression...) {
+        self.init(all: all, args)
     }
 
-    public init(_ args: [SQLExpression], all: Bool = false) {
-        self.args = args
+    public init(all: Bool = false, _ args: [SQLExpression]) {
         self.all = all
+        self.args = args
     }
 
     public func serialize(to serializer: inout SQLSerializer) {

--- a/Sources/SQLKit/Query/SQLUnion.swift
+++ b/Sources/SQLKit/Query/SQLUnion.swift
@@ -1,12 +1,14 @@
 public struct SQLUnion: SQLExpression {
     public let args: [SQLExpression]
+    public let all: Bool
 
-    public init(_ args: SQLExpression...) {
-        self.init(args)
+    public init(_ args: SQLExpression..., all: Bool = false) {
+        self.init(args, all: all)
     }
 
-    public init(_ args: [SQLExpression]) {
+    public init(_ args: [SQLExpression], all: Bool = false) {
         self.args = args
+        self.all = all
     }
 
     public func serialize(to serializer: inout SQLSerializer) {
@@ -14,7 +16,11 @@ public struct SQLUnion: SQLExpression {
         guard let first = groups.first else { return }
         first.serialize(to: &serializer)
         for arg in groups.dropFirst() {
-            serializer.write(" UNION ")
+            if all {
+                serializer.write(" UNION ALL ")
+            } else {
+                serializer.write(" UNION ")
+            }
             arg.serialize(to: &serializer)
         }
     }

--- a/Sources/SQLKit/Query/SQLUnion.swift
+++ b/Sources/SQLKit/Query/SQLUnion.swift
@@ -10,10 +10,10 @@ public struct SQLUnion: SQLExpression {
     }
 
     public func serialize(to serializer: inout SQLSerializer) {
-        let args = args.map(SQLGroupExpression.init)
-        guard let first = args.first else { return }
+        let groups = args.map(SQLGroupExpression.init)
+        guard let first = groups.first else { return }
         first.serialize(to: &serializer)
-        for arg in args.dropFirst() {
+        for arg in groups.dropFirst() {
             serializer.write(" UNION ")
             arg.serialize(to: &serializer)
         }

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -741,7 +741,8 @@ CREATE TABLE `planets`(`id` BIGINT, `name` TEXT, `diameter` INTEGER, `galaxy_nam
     }
 
     func testUnionAll() throws {
-        try db.unionAll(
+        try db.union(
+            all: true,
             db.select()
                 .column("id")
                 .from("t1"),

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -719,37 +719,36 @@ CREATE TABLE `planets`(`id` BIGINT, `name` TEXT, `diameter` INTEGER, `galaxy_nam
     }
 
     func testUnion() throws {
-        try db.union {
-            $0.column("id")
-                .from("t1")
-                .where("f1", .equal, "foo")
-                .limit(1)
-        }.union({
-            $0.column("id")
-                .from("t2")
-                .where("f2", .equal, "bar")
-                .limit(2)
-        }).union({
-            $0.column("id")
-                .from("t3")
-                .where("f3", .equal, "baz")
-                .limit(3)
-        })
-        .run().wait()
+        try db.select()
+            .column("id")
+            .from("t1")
+            .where("f1", .equal, "foo")
+            .limit(1)
+            .union({
+                $0.column("id")
+                    .from("t2")
+                    .where("f2", .equal, "bar")
+                    .limit(2)
+            }).union({
+                $0.column("id")
+                    .from("t3")
+                    .where("f3", .equal, "baz")
+                    .limit(3)
+            })
+            .run().wait()
 
         XCTAssertEqual(db.results[0], "(SELECT `id` FROM `t1` WHERE `f1` = ? LIMIT 1) UNION (SELECT `id` FROM `t2` WHERE `f2` = ? LIMIT 2) UNION (SELECT `id` FROM `t3` WHERE `f3` = ? LIMIT 3)")
     }
 
     func testUnionAll() throws {
-        try db.union {
-            $0.column("id")
-                .from("t1")
-        }
-        .union(all: {
-            $0.column("id")
-                .from("t2")
-        })
-        .run().wait()
+        try db.select()
+            .column("id")
+            .from("t1")
+            .union(all: {
+                $0.column("id")
+                    .from("t2")
+            })
+            .run().wait()
 
         XCTAssertEqual(db.results[0], "(SELECT `id` FROM `t1`) UNION ALL (SELECT `id` FROM `t2`)")
     }

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -741,8 +741,7 @@ CREATE TABLE `planets`(`id` BIGINT, `name` TEXT, `diameter` INTEGER, `galaxy_nam
     }
 
     func testUnionAll() throws {
-        try db.union(
-            all: true,
+        try db.union(all:
             db.select()
                 .column("id")
                 .from("t1"),

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -719,36 +719,37 @@ CREATE TABLE `planets`(`id` BIGINT, `name` TEXT, `diameter` INTEGER, `galaxy_nam
     }
 
     func testUnion() throws {
-        try db.union(
-            db.select()
-                .column("id")
+        try db.union {
+            $0.column("id")
                 .from("t1")
                 .where("f1", .equal, "foo")
-                .limit(1),
-            db.select()
-                .column("id")
+                .limit(1)
+        }.union({
+            $0.column("id")
                 .from("t2")
                 .where("f2", .equal, "bar")
-                .limit(2),
-            db.select()
-                .column("id")
+                .limit(2)
+        }).union({
+            $0.column("id")
                 .from("t3")
                 .where("f3", .equal, "baz")
                 .limit(3)
-        ).run().wait()
+        })
+        .run().wait()
 
         XCTAssertEqual(db.results[0], "(SELECT `id` FROM `t1` WHERE `f1` = ? LIMIT 1) UNION (SELECT `id` FROM `t2` WHERE `f2` = ? LIMIT 2) UNION (SELECT `id` FROM `t3` WHERE `f3` = ? LIMIT 3)")
     }
 
     func testUnionAll() throws {
-        try db.union(all:
-            db.select()
-                .column("id")
-                .from("t1"),
-            db.select()
-                .column("id")
+        try db.union {
+            $0.column("id")
+                .from("t1")
+        }
+        .union(all: {
+            $0.column("id")
                 .from("t2")
-        ).run().wait()
+        })
+        .run().wait()
 
         XCTAssertEqual(db.results[0], "(SELECT `id` FROM `t1`) UNION ALL (SELECT `id` FROM `t2`)")
     }

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -740,4 +740,17 @@ CREATE TABLE `planets`(`id` BIGINT, `name` TEXT, `diameter` INTEGER, `galaxy_nam
         XCTAssertEqual(db.results[0], "(SELECT `id` FROM `t1` WHERE `f1` = ? LIMIT 1) UNION (SELECT `id` FROM `t2` WHERE `f2` = ? LIMIT 2) UNION (SELECT `id` FROM `t3` WHERE `f3` = ? LIMIT 3)")
     }
 
+    func testUnionAll() throws {
+        try db.unionAll(
+            db.select()
+                .column("id")
+                .from("t1"),
+            db.select()
+                .column("id")
+                .from("t2")
+        ).run().wait()
+
+        XCTAssertEqual(db.results[0], "(SELECT `id` FROM `t1`) UNION ALL (SELECT `id` FROM `t2`)")
+    }
+
 }

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -724,15 +724,20 @@ CREATE TABLE `planets`(`id` BIGINT, `name` TEXT, `diameter` INTEGER, `galaxy_nam
                 .column("id")
                 .from("t1")
                 .where("f1", .equal, "foo")
-                .limit(2),
+                .limit(1),
             db.select()
                 .column("id")
                 .from("t2")
                 .where("f2", .equal, "bar")
+                .limit(2),
+            db.select()
+                .column("id")
+                .from("t3")
+                .where("f3", .equal, "baz")
                 .limit(3)
         ).run().wait()
 
-        XCTAssertEqual(db.results[0], "(SELECT `id` FROM `t1` WHERE `f1` = ? LIMIT 2) UNION (SELECT `id` FROM `t2` WHERE `f2` = ? LIMIT 3)")
+        XCTAssertEqual(db.results[0], "(SELECT `id` FROM `t1` WHERE `f1` = ? LIMIT 1) UNION (SELECT `id` FROM `t2` WHERE `f2` = ? LIMIT 2) UNION (SELECT `id` FROM `t3` WHERE `f3` = ? LIMIT 3)")
     }
 
 }

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -717,4 +717,22 @@ CREATE TABLE `planets`(`id` BIGINT, `name` TEXT, `diameter` INTEGER, `galaxy_nam
             XCTFail("Could not decode row with keyDecodingStrategy \(error)")
         }
     }
+
+    func testUnion() throws {
+        try db.union(
+            db.select()
+                .column("id")
+                .from("t1")
+                .where("f1", .equal, "foo")
+                .limit(2),
+            db.select()
+                .column("id")
+                .from("t2")
+                .where("f2", .equal, "bar")
+                .limit(3)
+        ).run().wait()
+
+        XCTAssertEqual(db.results[0], "(SELECT `id` FROM `t1` WHERE `f1` = ? LIMIT 2) UNION (SELECT `id` FROM `t2` WHERE `f2` = ? LIMIT 3)")
+    }
+
 }


### PR DESCRIPTION
Adds support for `UNION SELECT` queries:

```swift
try db.select()
     .column("id")
     .from("t1")
     .where("f1", .equal, "foo")
     .limit(1)
     .union({
         $0.column("id")
             .from("t2")
             .where("f2", .equal, "bar")
             .limit(2)
     }).union(all: {
         $0.column("id")
             .from("t3")
             .where("f3", .equal, "baz")
             .limit(3)
     })
     .run().wait()
```