### PR TITLE
Add support for `CREATE TABLE ... SELECT ...`

### DIFF
--- a/Sources/SQLKit/Builders/SQLCreateTableAsSubqueryBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLCreateTableAsSubqueryBuilder.swift
@@ -1,0 +1,14 @@
+/// A builder used to construct a `SELECT` query for use as part of a `CREATE TABLE` query.
+///
+/// - Note: There's really nothing for this builder to do besides provide a concrete storage
+///   for the `select` property of `SQLSubqueryClauseBuilder`. All of the interesting methods
+///   are on the protocol.
+public final class SQLCreateTableAsSubqueryBuilder: SQLSubqueryClauseBuilder {
+    // See `SQLSubqueryClauseBuilder.select`.
+    public var select: SQLSelect
+    
+    /// Create a new `SQLCreateTableAsSubqueryBuilder`.
+    internal init() {
+        self.select = .init()
+    }
+}

--- a/Sources/SQLKit/Builders/SQLCreateTableBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLCreateTableBuilder.swift
@@ -109,6 +109,17 @@ public final class SQLCreateTableBuilder: SQLQueryBuilder {
         createTable.ifNotExists = true
         return self
     }
+    
+    /// Specify a `SELECT` query to be used to populate the new table.
+    ///
+    /// If called more than once, each subsequent invocation overwrites the query from the one before.
+    @discardableResult
+    public func select(_ closure: (SQLCreateTableAsSubqueryBuilder) -> SQLCreateTableAsSubqueryBuilder) -> Self {
+        let builder = SQLCreateTableAsSubqueryBuilder()
+        _ = closure(builder)
+        createTable.asQuery = builder.select
+        return self
+    }
 }
 
 // MARK: Constraints

--- a/Sources/SQLKit/Builders/SQLDropTableBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLDropTableBuilder.swift
@@ -7,10 +7,10 @@ public final class SQLDropTableBuilder: SQLQueryBuilder {
     /// `DropTable` query being built.
     public var dropTable: SQLDropTable
     
-    /// See `SQLQueryBuilder`.
+    // See `SQLQueryBuilder.database`.
     public var database: SQLDatabase
     
-    /// See `SQLQueryBuilder`.
+    // See `SQLQueryBuilder.query`.
     public var query: SQLExpression {
         return self.dropTable
     }
@@ -51,6 +51,14 @@ public final class SQLDropTableBuilder: SQLQueryBuilder {
     @discardableResult
     public func restrict() -> Self {
         dropTable.behavior = SQLDropBehavior.restrict
+        return self
+    }
+
+    /// If the "TEMPORARY" keyword occurs between "DROP" and "TABLE" then only temporary tables are dropped,
+    /// and the drop does not cause an implicit transaction commit.
+    @discardableResult
+    public func temporary() -> Self {
+        dropTable.temporary = true
         return self
     }
 }

--- a/Sources/SQLKit/Builders/SQLPredicateBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLPredicateBuilder.swift
@@ -1,10 +1,10 @@
 /// Builds `SQLExpression` predicates, i.e., `WHERE` clauses.
 ///
-///     builder.where(\Planet.name == "Earth")
+///     builder.where("name", .equal, "Earth")
 ///
 /// Expressions will be added using `AND` logic by default. Use `orWhere` to join via `OR` logic.
 ///
-///     builder.where(\Planet.name == "Earth").orWhere(\Planet.name == "Mars")
+///     builder.where("name", .equal, "Earth").orWhere("name", .equal, "Mars")
 ///
 /// See `SQLPredicateGroupBuilder` for building expression groups.
 public protocol SQLPredicateBuilder: AnyObject {
@@ -19,15 +19,34 @@ extension SQLPredicateBuilder {
     ///
     /// This method compares two _columns_.
     ///
-    ///     SELECT * FROM users WHERE firstName = lastName
+    ///     SELECT * FROM "users" WHERE "firstName" = "lastName"
     ///
-    /// - parameters:
+    /// - Parameters:
     ///     - lhs: Left-hand side column name.
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Right-hand side column name.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func `where`(_ lhs: String, _ op: SQLBinaryOperator, column rhs: String) -> Self {
+        return self.where(SQLIdentifier(lhs), op, SQLIdentifier(rhs))
+    }
+
+    /// Adds a column to column comparison to this builder's `WHERE` clause by `AND`ing.
+    ///
+    ///     builder.where("firstName", .equal, column: "lastName")
+    ///
+    /// This method compares two _columns_.
+    ///
+    ///     SELECT * FROM "users" WHERE "firstName" = "lastName"
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column name.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side column name.
+    /// - Returns: `self` for chaining.
     @discardableResult
     public func `where`(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, column rhs: SQLIdentifier) -> Self {
-        self.where(lhs, op, rhs)
+        return self.where(SQLColumn(lhs), op, SQLColumn(rhs))
     }
 
     /// Adds a column to encodable comparison to this builder's `WHERE` clause by `AND`ing.
@@ -36,87 +55,103 @@ extension SQLPredicateBuilder {
     ///
     /// The encodable value supplied will be bound to the query as a parameter.
     ///
-    ///     SELECT * FROM planets WHERE name = ? // Earth
+    ///     SELECT * FROM "planets" WHERE "name" = ? // Earth
     ///
-    /// - parameters:
-    ///     - lhs: Left-hand side column name.
+    /// - Parameters:
+    ///     - lhs: Left-hand side column identifier.
     ///     - op: Binary operator to use for comparison.
-    ///     - rhs: Encodable value.
-    /// - returns: Self for chaining.
+    ///     - rhs: Typed `Encodable` value.
+    /// - Returns: `self` for chaining.
     @discardableResult
     public func `where`<E>(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: E) -> Self
         where E: Encodable
     {
-        return self.where(lhs, op, SQLBind(rhs))
+        return self.where(SQLColumn(lhs), op, SQLBind(rhs))
     }
 
-    /// Adds a column to encodable comparison to this builder's `WHERE` clause by `AND`ing.
+    /// Adds a column to encodable array comparison to this builder's `WHERE` clause by `AND`ing.
     ///
     ///     builder.where("name", .in, ["Earth", "Mars"])
     ///
-    /// The encodable value supplied will be bound to the query as a parameter.
+    /// The encodable values supplied will be bound to the query as parameters.
     ///
-    ///     SELECT * FROM planets WHERE name = (?, ?) // Earth, Mars
+    ///     SELECT * FROM "planets" WHERE "name" IN (?, ?) // Earth, Mars
     ///
-    /// - parameters:
-    ///     - lhs: Left-hand side column name.
+    /// - Parameters:
+    ///     - lhs: Left-hand side column identifier.
     ///     - op: Binary operator to use for comparison.
-    ///     - rhs: Encodable value.
-    /// - returns: Self for chaining.
+    ///     - rhs: Typed array of `Encodable` values.
+    /// - Returns: `self` for chaining.
     @discardableResult
     public func `where`<E>(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: [E]) -> Self
         where E: Encodable
     {
-        self.where(lhs, op, SQLBind.group(rhs))
+        return self.where(SQLColumn(lhs), op, SQLBind.group(rhs))
     }
 
-    /// Adds a column to expression comparison to the `WHERE` clause by `AND`ing.
+    /// Adds a column to expression comparison to this builder' `WHERE` clause by `AND`ing.
     ///
-    ///     builder.where(SQLIdentifier("name"), .equal, SQLBind("Earth"))
+    ///     builder.where("name", .equal, SQLLiteral.string("Earth"))
     ///
-    /// - parameters:
+    /// - Parameters:
     ///     - lhs: Left-hand side column name.
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Right-hand side expression.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func `where`(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
+        return self.where(SQLIdentifier(lhs), op, rhs)
+    }
+
+    /// Adds a column to expression comparison to this builder's `WHERE` clause by `AND`ing.
+    ///
+    ///     builder.where(SQLIdentifier("name"), .equal, SQLBind("Earth"))
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column identifier.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side expression.
+    /// - Returns: `self` for chaining.
     @discardableResult
     public func `where`(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
-        self.where(lhs, op as SQLExpression, rhs)
+        return self.where(SQLColumn(lhs), op, rhs)
     }
 
-    /// Adds a column to expression comparison to the `WHERE` clause by `AND`ing.
+    /// Adds an expression to expression comparison to this builder's `WHERE` clause by `AND`ing.
     ///
-    ///     builder.where(SQLIdentifier("name"), .equal, SQLBind("Earth"))
+    ///     builder.where(SQLColumn("name"), .equal, SQLBind("Earth"))
     ///
-    /// - parameters:
-    ///     - lhs: Left-hand side column name.
-    ///     - op: Binary operator to use for comparison.
-    ///     - rhs: Right-hand side expression.
-    @discardableResult
-    public func `where`(_ lhs: SQLExpression, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
-        self.where(lhs, op as SQLExpression, rhs)
-    }
-
-    /// Adds an expression to expression comparison, with an arbitrary
-    /// expression as operator, to the `WHERE` clause by `AND`ing.
-    ///
-    ///     builder.where(SQLIdentifier("name"), SQLBinaryOperator.equal, SQLBind("Earth"))
-    ///
-    /// - parameters:
+    /// - Parameters:
     ///     - lhs: Left-hand side expression.
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Right-hand side expression.
-    /// - returns: Self for chaining.
+    /// - Returns: `self` for chaining.
     @discardableResult
-    public func `where`(_ lhs: SQLExpression, _ op: SQLExpression, _ rhs: SQLExpression) -> Self {
-        self.where(SQLBinaryExpression(left: lhs, op: op, right: rhs))
+    public func `where`(_ lhs: SQLExpression, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
+        return self.where(lhs, op as SQLExpression, rhs)
     }
 
-    /// Adds an expression to the `WHERE` clause by `AND`ing.
+    /// Adds an expression to expression comparison with arbitrary operator expression to this
+    /// builder's `WHERE` clause by `AND`ing.
     ///
-    ///     builder.where(.binary("name", .notEqual, .literal(.null)))
+    ///     builder.where(SQLColumn("name"), SQLBinaryOperator.equal, SQLBind("Earth"))
     ///
-    /// - parameters:
-    ///     - expression: Expression to be added to the predicate.
+    /// - Parameters:
+    ///     - lhs: Left-hand side expression.
+    ///     - op: Operator expression.
+    ///     - rhs: Right-hand side expression.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func `where`(_ lhs: SQLExpression, _ op: SQLExpression, _ rhs: SQLExpression) -> Self {
+        return self.where(SQLBinaryExpression(left: lhs, op: op, right: rhs))
+    }
+
+    /// Adds an expression to this builder's `WHERE` clause by `AND`ing.
+    ///
+    ///     builder.where(SQLBinaryOperation(SQLColumn("name"), SQLBinaryOperator.notEqual, SQLLiteral.null))
+    ///
+    /// - Parameter expression: Expression to be added to the predicate.
+    /// - Returns: `self` for chaining.
     @discardableResult
     public func `where`(_ expression: SQLExpression) -> Self {
         if let existing = self.predicate {
@@ -130,113 +165,114 @@ extension SQLPredicateBuilder {
         }
         return self
     }
+}
+
+extension SQLPredicateBuilder {
+    /// Adds a column to column comparison to this builder's `WHERE` clause by `OR`ing.
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column name.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side column name.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func orWhere(_ lhs: String, _ op: SQLBinaryOperator, column rhs: String) -> Self {
+        return self.orWhere(SQLIdentifier(lhs), op, column: SQLIdentifier(rhs))
+    }
+
+    /// Adds a column to column comparison to this builder's `WHERE` clause by `OR`ing.
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column identifier.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side column identifier.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func orWhere(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, column rhs: SQLIdentifier) -> Self {
+        return self.orWhere(SQLColumn(lhs), op, SQLColumn(rhs))
+    }
+    
+    /// Adds a column to encodable comparison to this builder's `WHERE` clause by `OR`ing.
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column identifier.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Typed `Encodable` value.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func orWhere<E>(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: E) -> Self
+        where E: Encodable
+    {
+        return self.orWhere(SQLColumn(lhs), op, SQLBind(rhs))
+    }
+
+    /// Adds a column to encodable array comparison to this builder's `WHERE` clause by `OR`ing.
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column identifier.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Typed array of `Encodable` values.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func orWhere<E>(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: [E]) -> Self
+        where E: Encodable
+    {
+        return self.orWhere(SQLColumn(lhs), op, SQLBind.group(rhs))
+    }
 
     /// Adds a column to expression comparison to the `WHERE` clause by `OR`ing.
     ///
-    ///     builder.orWhere("name", .equal, .value("Earth"))
-    ///
-    /// - parameters:
+    /// - Parameters:
     ///     - lhs: Left-hand side column name.
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Right-hand side expression.
+    /// - Returns: `self` for chaining.
     @discardableResult
     public func orWhere(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
         return self.orWhere(SQLIdentifier(lhs), op, rhs)
     }
     
-    /// Adds a column to column comparison to this builder's `WHERE` clause by `OR`ing.
+    /// Adds a column to expression comparison to the `WHERE` clause by `OR`ing.
     ///
-    ///     builder.orWhere("firstName", .equal, column: "lastName")
-    ///
-    /// This method compares two _columns_.
-    ///
-    ///     SELECT * FROM users WHERE firstName = lastName
-    ///
-    /// - parameters:
-    ///     - lhs: Left-hand side column name.
+    /// - Parameters:
+    ///     - lhs: Left-hand side column identifier.
     ///     - op: Binary operator to use for comparison.
-    ///     - rhs: Right-hand side column name.
+    ///     - rhs: Right-hand side expression.
+    /// - Returns: `self` for chaining.
     @discardableResult
-    public func orWhere(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, column rhs: SQLIdentifier) -> Self {
-        return self.orWhere(lhs, op, rhs)
-    }
-    
-    /// Adds a column to encodable comparison to the `WHERE` clause by `OR`ing.
-    ///
-    ///     builder.orWhere("name", .equal, "Earth")
-    ///
-    /// The encodable value supplied will be bound to the query as a parameter.
-    ///
-    ///     SELECT * FROM planets WHERE name = ? // Earth
-    ///
-    /// - parameters:
-    ///     - lhs: Left-hand side column name.
-    ///     - op: Binary operator to use for comparison.
-    ///     - rhs: Encodable value.
-    /// - returns: Self for chaining.
-    @discardableResult
-    public func orWhere<E>(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: E) -> Self
-        where E: Encodable
-    {
-        return self.orWhere(lhs, op, SQLBind(rhs))
+    public func orWhere(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
+        return self.orWhere(SQLColumn(lhs), op, rhs)
     }
 
-    /// Adds a column to encodable comparison to this builder's `WHERE` clause by `AND`ing.
+    /// Adds an expression to expression comparison to this builder's `WHERE` clause by `OR`ing.
     ///
-    ///     builder.orWhere("name", .in, ["Earth", "Mars"])
-    ///
-    /// The encodable value supplied will be bound to the query as a parameter.
-    ///
-    ///     SELECT * FROM planets WHERE name IN (?, ?) // Earth, Mars
-    ///
-    /// - parameters:
-    ///     - lhs: Left-hand side column name.
-    ///     - op: Binary operator to use for comparison.
-    ///     - rhs: Encodable value.
-    /// - returns: Self for chaining.
-    @discardableResult
-    public func orWhere<E>(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: [E]) -> Self
-        where E: Encodable
-    {
-        self.orWhere(lhs, op, SQLBind.group(rhs))
-    }
-
-
-    /// Adds an expression to expression comparison to the `WHERE` clause by `OR`ing.
-    ///
-    ///     builder.orWhere("name", .equal, .value("Earth"))
-    ///
-    /// - parameters:
+    /// - Parameters:
     ///     - lhs: Left-hand side expression.
     ///     - op: Binary operator to use for comparison.
     ///     - rhs: Right-hand side expression.
-    /// - returns: Self for chaining.
+    /// - Returns: `self` for chaining.
     @discardableResult
     public func orWhere(_ lhs: SQLExpression, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
-        return self.orWhere(SQLBinaryExpression(left: lhs, op: op, right: rhs))
+        return self.orWhere(lhs, op as SQLExpression, rhs)
     }
 
-    /// Adds an expression to expression comparison, with an arbitrary
-    /// expression as operator, to the `WHERE` clause by `OR`ing.
+    /// Adds an expression to expression comparison with arbitrary operator expression to this
+    /// builder's `WHERE` clause by `OR`ing.
     ///
-    ///     builder.orWhere("name", .equal, .value("Earth"))
-    ///
-    /// - parameters:
+    /// - Parameters:
     ///     - lhs: Left-hand side expression.
-    ///     - op: Binary operator to use for comparison.
+    ///     - op: Operator expression.
     ///     - rhs: Right-hand side expression.
-    /// - returns: Self for chaining.
+    /// - Returns: `self` for chaining.
     @discardableResult
     public func orWhere(_ lhs: SQLExpression, _ op: SQLExpression, _ rhs: SQLExpression) -> Self {
         return self.orWhere(SQLBinaryExpression(left: lhs, op: op, right: rhs))
     }
 
-    /// Adds an expression to the `WHERE` clause by `OR`ing.
+    /// Adds an expression to this builder's `WHERE` clause by `OR`ing.
     ///
-    ///     builder.orWhere(.binary("name", .notEqual, .literal(.null)))
-    ///
-    /// - parameters:
-    ///     - expression: Expression to be added to the predicate.
+    /// - Parameter expression: Expression to be added to the predicate.
+    /// - Returns: `self` for chaining.
     @discardableResult
     public func orWhere(_ expression: SQLExpression) -> Self {
         if let existing = self.predicate {

--- a/Sources/SQLKit/Builders/SQLSecondaryPredicateBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLSecondaryPredicateBuilder.swift
@@ -1,0 +1,321 @@
+/// Builds secondary `SQLExpression` predicates, i.e., `HAVING` clauses.
+///
+///     builder.having("name", .equal, "Earth")
+///
+/// Expressions will be added using `AND` logic by default. Use `orHaving` to join via `OR` logic.
+///
+///     builder.having("name", .equal, "Earth").orHaving("name", .equal, "Mars")
+///
+/// See `SQLSecondaryPredicateGroupBuilder` for building expression groups.
+public protocol SQLSecondaryPredicateBuilder: AnyObject {
+    /// Expression being built.
+    var secondaryPredicate: SQLExpression? { get set }
+}
+
+extension SQLSecondaryPredicateBuilder {
+    /// Adds a column to column comparison to this builder's `HAVING` clause by `AND`ing.
+    ///
+    ///     builder.having("firstName", .equal, column: "lastName")
+    ///
+    /// This method compares two _columns_.
+    ///
+    ///     SELECT * FROM "users" HAVING "firstName" = "lastName"
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column name.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side column name.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func having(_ lhs: String, _ op: SQLBinaryOperator, column rhs: String) -> Self {
+        return self.having(SQLIdentifier(lhs), op, SQLIdentifier(rhs))
+    }
+
+    /// Adds a column to column comparison to this builder's `HAVING` clause by `AND`ing.
+    ///
+    ///     builder.having("firstName", .equal, column: "lastName")
+    ///
+    /// This method compares two _columns_.
+    ///
+    ///     SELECT * FROM "users" HAVING "firstName" = "lastName"
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column name.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side column name.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func having(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, column rhs: SQLIdentifier) -> Self {
+        return self.having(SQLColumn(lhs), op, SQLColumn(rhs))
+    }
+
+    /// Adds a column to encodable comparison to this builder's `HAVING` clause by `AND`ing.
+    ///
+    ///     builder.having("name", .equal, "Earth")
+    ///
+    /// The encodable value supplied will be bound to the query as a parameter.
+    ///
+    ///     SELECT * FROM "planets" HAVING "name" = ? // Earth
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column name.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Type-nonspecific `Encodable` value.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    @_disfavoredOverload // try to prefer the generic version
+    public func having(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: Encodable) -> Self {
+        return self.having(SQLColumn(lhs), op, SQLBind(rhs))
+    }
+
+    /// Adds a column to encodable comparison to this builder's `HAVING` clause by `AND`ing.
+    ///
+    ///     builder.having("name", .equal, "Earth")
+    ///
+    /// The encodable value supplied will be bound to the query as a parameter.
+    ///
+    ///     SELECT * FROM "planets" HAVING "name" = ? // Earth
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column identifier.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Typed `Encodable` value.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func having<E>(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: E) -> Self
+        where E: Encodable
+    {
+        return self.having(SQLColumn(lhs), op, SQLBind(rhs))
+    }
+
+    /// Adds a column to encodable array comparison to this builder's `HAVING` clause by `AND`ing.
+    ///
+    ///     builder.having("name", .in, ["Earth", "Mars"])
+    ///
+    /// The encodable values supplied will be bound to the query as parameters.
+    ///
+    ///     SELECT * FROM "planets" HAVING "name" IN (?, ?) // Earth, Mars
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column identifier.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Typed array of `Encodable` values.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func having<E>(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: [E]) -> Self
+        where E: Encodable
+    {
+        return self.having(SQLColumn(lhs), op, SQLBind.group(rhs))
+    }
+
+    /// Adds a column to expression comparison to this builder' `HAVING` clause by `AND`ing.
+    ///
+    ///     builder.having("name", .equal, SQLLiteral.string("Earth"))
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column name.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side expression.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func having(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
+        return self.having(SQLIdentifier(lhs), op, rhs)
+    }
+
+    /// Adds a column to expression comparison to this builder's `HAVING` clause by `AND`ing.
+    ///
+    ///     builder.having(SQLIdentifier("name"), .equal, SQLBind("Earth"))
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column identifier.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side expression.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func having(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
+        return self.having(SQLColumn(lhs), op, rhs)
+    }
+
+    /// Adds an expression to expression comparison to this builder's `HAVING` clause by `AND`ing.
+    ///
+    ///     builder.having(SQLColumn("name"), .equal, SQLBind("Earth"))
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side expression.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side expression.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func having(_ lhs: SQLExpression, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
+        return self.having(lhs, op as SQLExpression, rhs)
+    }
+
+    /// Adds an expression to expression comparison with arbitrary operator expression to this
+    /// builder's `HAVING` clause by `AND`ing.
+    ///
+    ///     builder.having(SQLColumn("name"), SQLBinaryOperator.equal, SQLBind("Earth"))
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side expression.
+    ///     - op: Operator expression.
+    ///     - rhs: Right-hand side expression.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func having(_ lhs: SQLExpression, _ op: SQLExpression, _ rhs: SQLExpression) -> Self {
+        return self.having(SQLBinaryExpression(left: lhs, op: op, right: rhs))
+    }
+
+    /// Adds an expression to this builder's `HAVING` clause by `AND`ing.
+    ///
+    ///     builder.having(SQLBinaryOperation(SQLColumn("name"), SQLBinaryOperator.notEqual, SQLLiteral.null))
+    ///
+    /// - Parameter expression: Expression to be added to the predicate.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func having(_ expression: SQLExpression) -> Self {
+        if let existing = self.secondaryPredicate {
+            self.secondaryPredicate = SQLBinaryExpression(
+                left: existing,
+                op: SQLBinaryOperator.and,
+                right: expression
+            )
+        } else {
+            self.secondaryPredicate = expression
+        }
+        return self
+    }
+}
+
+extension SQLSecondaryPredicateBuilder {
+    /// Adds a column to column comparison to this builder's `HAVING` clause by `OR`ing.
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column name.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side column name.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func orHaving(_ lhs: String, _ op: SQLBinaryOperator, column rhs: String) -> Self {
+        return self.orHaving(SQLIdentifier(lhs), op, column: SQLIdentifier(rhs))
+    }
+
+    /// Adds a column to column comparison to this builder's `HAVING` clause by `OR`ing.
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column identifier.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side column identifier.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func orHaving(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, column rhs: SQLIdentifier) -> Self {
+        return self.orHaving(SQLColumn(lhs), op, SQLColumn(rhs))
+    }
+    
+    /// Adds a column to encodable comparison to this builder's `HAVING` clause by `OR`ing.
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column name.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Type-nonspecific `Encodable` value.
+    /// - Returns: Self for chaining.
+    @discardableResult
+    @_disfavoredOverload // try to prefer the generic version
+    public func orHaving(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: Encodable) -> Self {
+        return self.orHaving(SQLColumn(lhs), op, SQLBind(rhs))
+    }
+
+    /// Adds a column to encodable comparison to this builder's `HAVING` clause by `OR`ing.
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column identifier.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Typed `Encodable` value.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func orHaving<E>(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: E) -> Self
+        where E: Encodable
+    {
+        return self.orHaving(SQLColumn(lhs), op, SQLBind(rhs))
+    }
+
+    /// Adds a column to encodable array comparison to this builder's `HAVING` clause by `OR`ing.
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column identifier.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Typed array of `Encodable` values.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func orHaving<E>(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: [E]) -> Self
+        where E: Encodable
+    {
+        return self.orHaving(SQLColumn(lhs), op, SQLBind.group(rhs))
+    }
+
+    /// Adds a column to expression comparison to the `HAVING` clause by `OR`ing.
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column name.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side expression.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func orHaving(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
+        return self.orHaving(SQLIdentifier(lhs), op, rhs)
+    }
+    
+    /// Adds a column to expression comparison to the `HAVING` clause by `OR`ing.
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side column identifier.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side expression.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func orHaving(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
+        return self.orHaving(SQLColumn(lhs), op, rhs)
+    }
+
+    /// Adds an expression to expression comparison to this builder's `HAVING` clause by `OR`ing.
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side expression.
+    ///     - op: Binary operator to use for comparison.
+    ///     - rhs: Right-hand side expression.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func orHaving(_ lhs: SQLExpression, _ op: SQLBinaryOperator, _ rhs: SQLExpression) -> Self {
+        return self.orHaving(lhs, op as SQLExpression, rhs)
+    }
+
+    /// Adds an expression to expression comparison with arbitrary operator expression to this
+    /// builder's `HAVING` clause by `OR`ing.
+    ///
+    /// - Parameters:
+    ///     - lhs: Left-hand side expression.
+    ///     - op: Operator expression.
+    ///     - rhs: Right-hand side expression.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func orHaving(_ lhs: SQLExpression, _ op: SQLExpression, _ rhs: SQLExpression) -> Self {
+        return self.orHaving(SQLBinaryExpression(left: lhs, op: op, right: rhs))
+    }
+
+    /// Adds an expression to this builder's `HAVING` clause by `OR`ing.
+    ///
+    /// - Parameter expression: Expression to be added to the predicate.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func orHaving(_ expression: SQLExpression) -> Self {
+        if let existing = self.secondaryPredicate {
+            self.secondaryPredicate = SQLBinaryExpression(
+                left: existing,
+                op: SQLBinaryOperator.or,
+                right: expression
+            )
+        } else {
+            self.secondaryPredicate = expression
+        }
+        return self
+    }
+}

--- a/Sources/SQLKit/Builders/SQLSecondaryPredicateGroupBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLSecondaryPredicateGroupBuilder.swift
@@ -1,0 +1,73 @@
+/// Nested `SQLSecondaryPredicateBuilder` for building expression groups.
+///
+/// ```swift
+/// builder.having("type", .equal, .smallRocky).having {
+///     $0.having("name", .equal, "Earth")
+///       .orHaving("name", .equal, "Mars")
+/// }
+/// ```
+public final class SQLSecondaryPredicateGroupBuilder: SQLSecondaryPredicateBuilder {
+    // See `SQLSecondaryPredicateBuilder.secondaryPredicate`.
+    public var secondaryPredicate: SQLExpression?
+    
+    /// Creates a new `SQLSecondaryPredicateGroupBuilder`.
+    internal init() { }
+}
+
+extension SQLSecondaryPredicateBuilder {
+    /// Builds a grouped `HAVING` expression by conjunction ('AND').
+    ///
+    /// The following expression:
+    ///
+    /// ```swift
+    /// builder.having("type", .equal, .smallRocky).having {
+    ///     $0.having("name", .equal, "Earth")
+    ///       .orHaving("name", .equal, "Mars")
+    /// }
+    /// ```
+    ///
+    /// ... will result in SQL similar to:
+    ///
+    /// ```sql
+    /// HAVING "type" = 'smallRocky' AND
+    ///     ("name" = 'Earth' OR "name" = 'Mars')
+    /// ```
+    @discardableResult
+    public func having(group: (SQLSecondaryPredicateGroupBuilder) -> (SQLSecondaryPredicateGroupBuilder)) -> Self {
+        let builder = SQLSecondaryPredicateGroupBuilder()
+        _ = group(builder)
+        if let sub = builder.secondaryPredicate {
+            return self.having(SQLGroupExpression(sub))
+        } else {
+            return self
+        }
+    }
+    
+    /// Builds a grouped `HAVING` expression by disjunction ('OR').
+    ///
+    /// The following expression:
+    ///
+    /// ```swift
+    /// builder.having("name", .equal, "Jupiter").orHaving {
+    ///     $0.having("name", .equal, "Earth")
+    ///       .having("type", .equal, .smallRocky)
+    /// }
+    /// ```
+    ///
+    /// ... will result in SQL similar to:
+    ///
+    /// ```sql
+    /// HAVING "name" = 'Jupiter' OR
+    ///     ("name" = 'Earth' AND "type" = 'smallRocky')
+    /// ```
+    @discardableResult
+    public func orHaving(group: (SQLSecondaryPredicateGroupBuilder) -> (SQLSecondaryPredicateGroupBuilder)) -> Self {
+        let builder = SQLSecondaryPredicateGroupBuilder()
+        _ = group(builder)
+        if let sub = builder.secondaryPredicate {
+            return self.orHaving(SQLGroupExpression(sub))
+        } else {
+            return self
+        }
+    }
+}

--- a/Sources/SQLKit/Builders/SQLSelectBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLSelectBuilder.swift
@@ -1,69 +1,41 @@
 extension SQLDatabase {
     /// Creates a new `SQLSelectBuilder`.
     ///
-    ///     db.select()
-    ///         .column("*")
-    ///         .from("planets"")
-    ///         .where("name", .equal, SQLBind("Earth"))
-    ///         .all()
-    ///
+    /// ```sql
+    /// db.select()
+    ///     .column("*")
+    ///     .from("planets"")
+    ///     .where("name", .equal, SQLBind("Earth"))
+    ///     .all()
+    /// ```
     public func select() -> SQLSelectBuilder {
         return .init(on: self)
     }
 }
 
-
-public final class SQLSelectBuilder: SQLQueryFetcher, SQLQueryBuilder {
+/// A builder for constructing, executing, and retrieving results from `SELECT` queries.
+public final class SQLSelectBuilder: SQLQueryFetcher, SQLQueryBuilder, SQLSubqueryClauseBuilder {
+    // See `SQLQueryBuilder.query`.
     public var query: SQLExpression {
         return self.select
     }
     
+    // See `SQLSubqueryClauseBuilder.select`.
     public var select: SQLSelect
+    
+    // See `SQLQueryBuilder.database`.
     public var database: SQLDatabase
     
+    /// Create a new `SQLSelectBuilder` on the given database.
     public init(on database: SQLDatabase) {
         self.select = .init()
         self.database = database
     }
 }
 
-// MARK: Joins
-
-extension SQLSelectBuilder: SQLJoinBuilder {
-    public var joins: [SQLExpression] {
-        get { self.select.joins }
-        set { self.select.joins = newValue }
-    }
-}
-
-// MARK: Predicate
-
-extension SQLSelectBuilder: SQLPredicateBuilder {
-    public var predicate: SQLExpression? {
-        get { return self.select.predicate }
-        set { self.select.predicate = newValue }
-    }
-}
-
-extension SQLSelectBuilder: SQLSecondaryPredicateBuilder {
-    public var secondaryPredicate: SQLExpression? {
-        get { return self.select.having }
-        set { self.select.having = newValue }
-    }
-}
-
-// MARK: Distinct
+// - MARK: Additional distinct clauses
 
 extension SQLSelectBuilder {
-    /// Adds a `DISTINCT` clause to the select statement.
-    ///
-    /// - Returns: `self` for chaining.
-    @discardableResult
-    public func distinct() -> Self {
-        self.select.isDistinct = true
-        return self
-    }
-
     /// Adds a `DISTINCT` clause to the select statement and explicitly specifies columns to select,
     /// overwriting any previously specified columns.
     ///
@@ -71,8 +43,8 @@ extension SQLSelectBuilder {
     ///
     /// - Returns: `self` for chaining.
     @discardableResult
-    public func distinct(on columns: String...) -> Self {
-        return self.distinct(on: columns.map(SQLIdentifier.init(_:)))
+    public func distinct(on column: String, _ columns: String...) -> Self {
+        return self.distinct(on: ([column] + columns).map(SQLIdentifier.init(_:)))
     }
     
     /// Adds a `DISTINCT` clause to the select statement and explicitly specifies columns to select,
@@ -82,8 +54,8 @@ extension SQLSelectBuilder {
     ///
     /// - Returns: `self` for chaining.
     @discardableResult
-    public func distinct(on columns: SQLExpression...) -> Self {
-        return self.distinct(on: columns)
+    public func distinct(on column: SQLExpression, _ columns: SQLExpression...) -> Self {
+        return self.distinct(on: [column] + columns)
     }
     
     /// Adds a `DISTINCT` clause to the select statement and explicitly specifies columns to select,
@@ -96,296 +68,6 @@ extension SQLSelectBuilder {
     public func distinct(on columns: [SQLExpression]) -> Self {
         self.select.isDistinct = true
         self.select.columns = columns
-        return self
-    }
-}
-
-// MARK: Columns
-
-extension SQLSelectBuilder {
-    /// Specify a column to be part of the result set of the query. The column
-    /// is a string assumed to be a valid SQL identifier and is not qualified.
-    /// The string "*" (a single asterisk) is recognized and replaced by
-    /// `SQLLiteral.all`.
-    ///
-    /// - Parameter column: The name of the column to return, or "*" for all.
-    @discardableResult
-    public func column(_ column: String) -> Self {
-        if column == "*" {
-            return self.column(SQLLiteral.all)
-        } else {
-            return self.column(SQLIdentifier(column))
-        }
-    }
-    
-    /// Specify a column to be part of the result set of the query. The column
-    /// is a string assumed to be a valid SQL identifier and is qualified by a
-    /// table name, also a string assumed to be a valid SQL identifier.
-    ///
-    /// - Parameters:
-    ///   - table: The name of a table to qualify the column name.
-    ///   - column: The name of the column to return.
-    ///   The string "*" (a single asterisk) is recognized and replaced by
-    ///   `SQLLiteral.all`.
-    @discardableResult
-    public func column(table: String, column: String) -> Self {
-        let columnExpr: SQLExpression
-        if column == "*" {
-            columnExpr = SQLLiteral.all
-        } else {
-            columnExpr = SQLIdentifier(column)
-        }
-        return self.column(SQLColumn(columnExpr, table: SQLIdentifier(table)))
-    }
-    
-    /// Specify a column to be part of the result set of the query. The column
-    /// is an arbitrary expression.
-    ///
-    /// - Parameter expr: An expression identifying the desired data to return.
-    @discardableResult
-    public func column(_ expr: SQLExpression) -> Self {
-        self.select.columns.append(expr)
-        return self
-    }
-    
-    /// Specify a list of columns to be part of the result set of the query.
-    /// Each provided name is a string assumed to be a valid SQL identifier and
-    /// is not qualified. The string "*" is recognized and replaced by
-    /// `SQLLiteral.all`.
-    ///
-    /// - Parameter columns: The names of the columns to return.
-    @discardableResult
-    public func columns(_ columns: String...) -> Self {
-        return columns.reduce(self) { $0.column($1) }
-    }
-    
-    /// Specify a list of columns to be part of the result set of the query.
-    /// Each provided name is a string assumed to be a valid SQL identifier and
-    /// is not qualified. The string "*" is recognized and replaced by
-    /// `SQLLiteral.all`.
-    ///
-    /// - Parameter columns: The names of the columns to return.
-    @discardableResult
-    public func columns(_ columns: [String]) -> Self {
-        return columns.reduce(self) { $0.column($1) }
-    }
-    
-    /// Specify a list of columns to be part of the result set of the query.
-    /// Each input is an arbitrary expression.
-    ///
-    /// - Parameter columns: A list of expressions identifying the desired data
-    ///                      to return.
-    @discardableResult
-    public func columns(_ columns: SQLExpression...) -> Self {
-        return self.columns(columns)
-    }
-    
-    /// Specify a list of columns to be part of the result set of the query.
-    /// Each input is an arbitrary expression.
-    ///
-    /// - Parameter columns: A list of expressions identifying the desired data
-    ///                      to return.
-    @discardableResult
-    public func columns(_ columns: [SQLExpression]) -> Self {
-        return columns.reduce(self) { $0.column($1) }
-    }
-
-    /// Specify a column to retrieve as a `String`, and an alias for it with another `String`.
-    @discardableResult
-    public func column(_ column: String, as alias: String) -> Self {
-        self.column(SQLIdentifier(column), as: SQLIdentifier(alias))
-    }
-
-    /// Specify a column to retrieve as an `SQLExpression`, and an alias for it with a `String`.
-    @discardableResult
-    public func column(_ column: SQLExpression, as alias: String) -> Self {
-        self.column(column, as: SQLIdentifier(alias))
-    }
-
-    /// Specify a column to retrieve as an `SQLExpression`, and an alias for it with another `SQLExpression`.
-    @discardableResult
-    public func column(_ column: SQLExpression, as alias: SQLExpression) -> Self {
-        self.column(SQLAlias(column, as: alias))
-    }
-}
-
-// MARK: From
-
-extension SQLSelectBuilder {
-    /// Include the given table in the list of those used by the query, without
-    /// performing an explicit join. The table specifier is a string assumed to
-    /// be a valid SQL identifier.
-    ///
-    /// - Parameter table: The name of the table to use.
-    @discardableResult
-    public func from(_ table: String) -> Self {
-        return self.from(SQLIdentifier(table))
-    }
-    
-    /// Include the given table in the list of those used by the query, without
-    /// performing an explicit join. The table specifier may be any expression.
-    ///
-    /// - Parameters:
-    ///   - table: An expression identifying the table to use.
-    @discardableResult
-    public func from(_ table: SQLExpression) -> Self {
-        self.select.tables.append(table)
-        return self
-    }
-    
-    /// Include the given table in the list of those used by the query, without
-    /// performing an explicit join. An alias for the table may be provided. The
-    /// table and alias specifiers are strings assumed to be valid SQL
-    /// identifiers.
-    ///
-    /// - Parameters:
-    ///   - table: The name of the table to use.
-    ///   - alias: The alias to use for the table.
-    @discardableResult
-    public func from(_ table: String, as alias: String) -> Self {
-        return self.from(SQLIdentifier(table), as: SQLIdentifier(alias))
-    }
-    
-    /// Include the given table in the list of those used by the query, without
-    /// performing an explicit join. The table and alias specifiers may be
-    /// arbitrary expressions.
-    ///
-    /// - Parameters:
-    ///   - table: An expression identifying the table to use.
-    ///   - alias: An expression providing the alias to use for the table.
-    @discardableResult
-    public func from(_ table: SQLExpression, as alias: SQLExpression) -> Self {
-        return self.from(SQLAlias(table, as: alias))
-    }
-
-}
-
-// MARK: Limit / Offset
-
-extension SQLSelectBuilder {
-    /// Adds a `LIMIT` clause to the select statement.
-    ///
-    ///     builder.limit(5)
-    ///
-    /// - parameters:
-    ///     - max: Optional maximum limit.
-    ///            If `nil`, existing limit will be removed.
-    /// - returns: Self for chaining.
-    @discardableResult
-    public func limit(_ max: Int?) -> Self {
-        self.select.limit = max
-        return self
-    }
-
-    /// Adds a `OFFSET` clause to the select statement.
-    ///
-    ///     builder.offset(5)
-    ///
-    /// - parameters:
-    ///     - max: Optional offset.
-    ///            If `nil`, existing offset will be removed.
-    /// - returns: Self for chaining.
-    @discardableResult
-    public func offset(_ n: Int?) -> Self {
-        self.select.offset = n
-        return self
-    }
-}
-
-// MARK: Group By
-
-extension SQLSelectBuilder {
-    /// Adds a `GROUP BY` clause to the select statement.
-    ///
-    /// - parameters:
-    ///     - expression: `SQLExpression` to group by.
-    /// - returns: Self for chaining.
-    @discardableResult
-    public func groupBy(_ column: String) -> Self {
-        return self.groupBy(SQLColumn(column))
-    }
-
-    /// Adds a `GROUP BY` clause to the select statement.
-    ///
-    /// - parameters:
-    ///     - expression: `SQLExpression` to group by.
-    /// - returns: Self for chaining.
-    @discardableResult
-    public func groupBy(_ expression: SQLExpression) -> Self {
-        self.select.groupBy.append(expression)
-        return self
-    }
-
-    /// Adds an `ORDER BY` clause to the select statement.
-    ///
-    /// - parameters:
-    ///     - expression: `SQLExpression` to order by.
-    /// - returns: Self for chaining.
-    @discardableResult
-    public func orderBy(_ column: String, _ direction: SQLDirection = .ascending) -> Self {
-        return self.orderBy(SQLColumn(column), direction)
-    }
-
-
-    /// Adds an `ORDER BY` clause to the select statement.
-    ///
-    /// - parameters:
-    ///     - expression: `SQLExpression` to order by.
-    /// - returns: Self for chaining.
-    @discardableResult
-    public func orderBy(_ expression: SQLExpression, _ direction: SQLExpression) -> Self {
-        return self.orderBy(SQLOrderBy(expression: expression, direction: direction))
-    }
-
-    /// Adds an `ORDER BY` clause to the select statement.
-    ///
-    /// - parameters:
-    ///     - expression: `SQLExpression` to order by.
-    /// - returns: Self for chaining.
-    @discardableResult
-    public func orderBy(_ expression: SQLExpression) -> Self {
-        select.orderBy.append(expression)
-        return self
-    }
-}
-
-
-// MARK: Locking
-
-extension SQLSelectBuilder {
-    /// Adds a locking expression to this `SELECT` statement.
-    ///
-    ///     db.select()...for(.update)
-    ///
-    /// Also called locking reads, the `SELECT ... FOR UPDATE` syntax
-    /// will lock all selected rows for the duration of the current transaction.
-    /// How the rows are locked depends on the specific expression supplied.
-    ///
-    /// - parameters:
-    ///     - lockingClause: Locking clause type.
-    /// - returns: Self for chaining.
-    @discardableResult
-    public func `for`(_ lockingClause: SQLLockingClause) -> Self {
-        return self.lockingClause(lockingClause)
-    }
-
-    /// Adds a locking expression to this `SELECT` statement.
-    ///
-    ///     db.select()...lockingClause(...)
-    ///
-    /// Also called locking reads, the `SELECT ... FOR UPDATE` syntax
-    /// will lock all selected rows for the duration of the current transaction.
-    /// How the rows are locked depends on the specific expression supplied.
-    ///
-    /// - note: This method allows for any `SQLExpression` conforming
-    ///         type to be passed as the locking clause.
-    ///
-    /// - parameters:
-    ///     - lockingClause: Locking clause type.
-    /// - returns: Self for chaining.
-    @discardableResult
-    public func lockingClause(_ lockingClause: SQLExpression) -> Self {
-        self.select.lockingClause = lockingClause
         return self
     }
 }

--- a/Sources/SQLKit/Builders/SQLSubqeryClauseBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLSubqeryClauseBuilder.swift
@@ -1,0 +1,346 @@
+/// A builder which can construct - but _not_ execute - a complete `SELECT` query.
+/// Useful for building CTEs, `CREATE TABLE ... SELECT` clauses, etc., not to
+/// mention actual `SELECT` queries.
+///
+/// - Important: Despite the use of the term "subquery", this builder does not provide
+///   methods for specifying subquery operators (e.g. `ANY`, `SOME`) or CTE clauses (`WITH`),
+///   nor does it enclose its result in grouping parenthesis, as all of these formations are
+///   context-specific and are the purview of builders that conform to this protocol.
+///
+/// - Note: The primary motivation for the existence of this protocol is to make it easier
+///   to construct `SELECT` queries without specifying a database or providing the
+///   `SQLQueryBuilder` and `SQLQueryFetcher` methods in inappropriate contexts.
+public protocol SQLSubqueryClauseBuilder: SQLJoinBuilder, SQLPredicateBuilder, SQLSecondaryPredicateBuilder {
+    var select: SQLSelect { get set }
+}
+
+extension SQLSubqueryClauseBuilder {
+    public var joins: [SQLExpression] {
+        get { self.select.joins }
+        set { self.select.joins = newValue }
+    }
+}
+
+extension SQLSubqueryClauseBuilder {
+    public var predicate: SQLExpression? {
+        get { return self.select.predicate }
+        set { self.select.predicate = newValue }
+    }
+}
+
+extension SQLSubqueryClauseBuilder {
+    public var secondaryPredicate: SQLExpression? {
+        get { return self.select.having }
+        set { self.select.having = newValue }
+    }
+}
+
+// MARK: - Distinct
+
+extension SQLSubqueryClauseBuilder {
+    /// Adds a `DISTINCT` clause to the query.
+    ///
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func distinct() -> Self {
+        self.select.isDistinct = true
+        return self
+    }
+}
+
+// MARK: - Columns
+
+extension SQLSubqueryClauseBuilder {
+    /// Specify a column to be part of the result set of the query. The column is a string
+    /// assumed to be a valid SQL identifier and is not qualified.
+    ///
+    /// The string `*` (a single asterisk) is recognized and replaced with `SQLLiteral.all`.
+    ///
+    /// - Parameter column: The name of the column to return, or `*` for all.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func column(_ column: String) -> Self {
+        if column == "*" {
+            return self.column(SQLLiteral.all)
+        } else {
+            return self.column(SQLColumn(SQLIdentifier(column)))
+        }
+    }
+    
+    /// Specify a column to be part of the result set of the query. The column is a string
+    /// assumed to be a valid SQL identifier, qualified by a table name, also a string assumed
+    /// to be a valid SQL identifier.
+    ///
+    /// The string `*` (a single asterisk) is recognized and replaced with `SQLLiteral.all`.
+    ///
+    /// - Parameters:
+    ///   - table: The name of a table to qualify the column name.
+    ///   - column: The name of the column to return, or `*` for all.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func column(table: String, column: String) -> Self {
+        if column == "*" {
+            return self.column(SQLColumn(SQLLiteral.all, table: SQLIdentifier(table)))
+        } else {
+            return self.column(SQLColumn(SQLIdentifier(column), table: SQLIdentifier(table)))
+        }
+    }
+
+    /// Specify a column to retrieve as a `String`, and an alias for it with another `String`.
+    ///
+    /// - Parameters:
+    ///   - column: The name of the column to return.
+    ///   - alias: The label to give the returned column.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func column(_ column: String, as alias: String) -> Self {
+        return self.column(SQLIdentifier(column), as: SQLIdentifier(alias))
+    }
+
+    /// Specify a column to retrieve as an `SQLExpression`, and an alias for it with a `String`.
+    ///
+    /// - Parameters:
+    ///   - column: An expression identifying the desired data to return.
+    ///   - alias: A string specifying the desired label of the identified data.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func column(_ column: SQLExpression, as alias: String) -> Self {
+        return self.column(column, as: SQLIdentifier(alias))
+    }
+
+    /// Specify a column to retrieve as an `SQLExpression`, and an alias for it with another `SQLExpression`.
+    ///
+    /// - Parameters:
+    ///   - column: An expression identifying the desired data to return.
+    ///   - alias: An expression specifying the desired label of the identified data.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func column(_ column: SQLExpression, as alias: SQLExpression) -> Self {
+        return self.column(SQLAlias(column, as: alias))
+    }
+
+    /// Specify an arbitrary expression as a column to be part of the result set of the query.
+    ///
+    /// - Parameter expr: An expression identifying the desired data to return.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func column(_ expr: SQLExpression) -> Self {
+        self.select.columns.append(expr)
+        return self
+    }
+    
+    /// Specify a list of columns to be part of the result set of the query. Each provided name
+    /// is a string assumed to be a valid SQL identifier and is not qualified. The string `*` is
+    /// recognized and replaced with `SQLLiteral.all`.
+    ///
+    /// - Parameter columns: The names of the columns to return.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func columns(_ columns: String...) -> Self {
+        return self.columns(columns)
+    }
+    
+    /// Specify a list of columns to be part of the result set of the query. Each provided name
+    /// is a string assumed to be a valid SQL identifier and is not qualified. The string `*` is
+    /// recognized and replaced with `SQLLiteral.all`.
+    ///
+    /// - Parameter columns: The names of the columns to return.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func columns(_ columns: [String]) -> Self {
+        return columns.reduce(self) { $0.column($1) }
+    }
+    
+    /// Specify a list of arbitrary expressions as columns to be part of the result set of the query.
+    ///
+    /// - Parameter columns: A list of expressions identifying the desired data to return.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func columns(_ columns: SQLExpression...) -> Self {
+        return self.columns(columns)
+    }
+    
+    /// Specify a list of arbitrary expressions as columns to be part of the result set of the query.
+    ///
+    /// - Parameter columns: A list of expressions identifying the desired data to return.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func columns(_ columns: [SQLExpression]) -> Self {
+        return columns.reduce(self) { $0.column($1) }
+    }
+}
+
+// MARK: - From
+
+extension SQLSubqueryClauseBuilder {
+    /// Include the given table in the list of those used by the query, without performing an
+    /// explicit join. The table specifier is a string assumed to be a valid SQL identifier.
+    ///
+    /// - Parameter table: The name of the table to use.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func from(_ table: String) -> Self {
+        return self.from(SQLIdentifier(table))
+    }
+    
+    /// Include the given table in the list of those used by the query, without performing an
+    /// explicit join. The table specifier may be any expression.
+    ///
+    /// - Parameter table: An expression identifying the table to use.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func from(_ table: SQLExpression) -> Self {
+        self.select.tables.append(table)
+        return self
+    }
+    
+    /// Include the given table in the list of those used by the query, without performing an
+    /// explicit join. An alias for the table may be provided. The table and alias specifiers
+    /// are strings assumed to be valid SQL identifiers.
+    ///
+    /// - Parameters:
+    ///   - table: The name of the table to use.
+    ///   - alias: The alias to use for the table.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func from(_ table: String, as alias: String) -> Self {
+        return self.from(SQLIdentifier(table), as: SQLIdentifier(alias))
+    }
+    
+    /// Include the given table in the list of those used by the query, without performing an
+    /// explicit join. The table and alias specifiers may be arbitrary expressions.
+    ///
+    /// - Parameters:
+    ///   - table: An expression identifying the table to use.
+    ///   - alias: An expression providing the alias to use for the table.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func from(_ table: SQLExpression, as alias: SQLExpression) -> Self {
+        return self.from(SQLAlias(table, as: alias))
+    }
+}
+
+// MARK: - Limit/offset
+
+extension SQLSubqueryClauseBuilder {
+    /// Adds a `LIMIT` clause to the query. If called more than once, the last call wins.
+    ///
+    /// - Parameter max: Optional maximum limit. If `nil`, any existing limit is removed.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func limit(_ max: Int?) -> Self {
+        self.select.limit = max
+        return self
+    }
+
+    /// Adds a `OFFSET` clause to the query. If called more than once, the last call wins.
+    ///
+    /// - Parameter max: Optional offset. If `nil`, any existing offset is removed.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func offset(_ n: Int?) -> Self {
+        self.select.offset = n
+        return self
+    }
+}
+
+// MARK: - Group By
+
+extension SQLSubqueryClauseBuilder {
+    /// Adds a `GROUP BY` clause to the query with the specified column.
+    ///
+    /// - Parameter column: Name of column to group results by. Appended to any previously added grouping expressions.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func groupBy(_ column: String) -> Self {
+        return self.groupBy(SQLColumn(column))
+    }
+
+    /// Adds a `GROUP BY` clause to the query with the specified expression.
+    ///
+    /// - Parameter expression: Expression to group results by. Appended to any previously added grouping expressions.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func groupBy(_ expression: SQLExpression) -> Self {
+        self.select.groupBy.append(expression)
+        return self
+    }
+}
+
+// MARK: - Order
+
+extension SQLSubqueryClauseBuilder {
+    /// Adds an `ORDER BY` clause to the query with the specified column and ordering.
+    ///
+    /// - Parameters:
+    ///   - column: Name of column to sort results by. Appended to any previously added orderings.
+    ///   - direction: The sort direction for the column.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func orderBy(_ column: String, _ direction: SQLDirection = .ascending) -> Self {
+        return self.orderBy(SQLColumn(column), direction)
+    }
+
+
+    /// Adds an `ORDER BY` clause to the query with the specifed expression and ordering.
+    ///
+    /// - Parameters:
+    ///   - expression: Expression to sort results by. Appended to any previously added orderings.
+    ///   - direction: An expression describing the sort direction for the ordering expression.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func orderBy(_ expression: SQLExpression, _ direction: SQLExpression) -> Self {
+        return self.orderBy(SQLOrderBy(expression: expression, direction: direction))
+    }
+
+    /// Adds an `ORDER BY` clause to the query using the specified expression.
+    ///
+    /// - Parameter expression: Expression to sort results by. Appended to any previously added orderings.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func orderBy(_ expression: SQLExpression) -> Self {
+        select.orderBy.append(expression)
+        return self
+    }
+}
+
+// MARK: - Locking
+
+extension SQLSubqueryClauseBuilder {
+    /// Adds a locking clause to this query. If called more than once, the last call wins.
+    ///
+    /// ```swift
+    /// db.select()...for(.update)
+    /// ```
+    ///
+    /// Also called locking reads, the `SELECT ... FOR UPDATE` syntax locks all selected rows
+    /// for the duration of the current transaction. How the rows are locked depends on the
+    /// specific expression supplied and the underlying database implementation.
+    ///
+    /// - Parameter lockingClause: The type of lock to obtain.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func `for`(_ lockingClause: SQLLockingClause) -> Self {
+        return self.lockingClause(lockingClause)
+    }
+
+    /// Adds a locking clause to this query. If called more than once, the last call wins.
+    ///
+    /// ```swift
+    /// db.select()...lockingClause(...)
+    /// ```
+    ///
+    /// Also called locking reads, the `SELECT ... FOR UPDATE` syntax locks all selected rows
+    /// for the duration of the current transaction. How the rows are locked depends on the
+    /// specific expression supplied and the underlying database implementation.
+    ///
+    /// - Note: This method allows providing an arbitrary SQL expression as the locking clause.
+    ///
+    /// - Parameter lockingClause: The locking clause as an SQL expression.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func lockingClause(_ lockingClause: SQLExpression) -> Self {
+        self.select.lockingClause = lockingClause
+        return self
+    }
+}

--- a/Sources/SQLKit/Query/SQLCreateTable.swift
+++ b/Sources/SQLKit/Query/SQLCreateTable.swift
@@ -21,6 +21,9 @@ public struct SQLCreateTable: SQLExpression {
     /// Table constraints, such as `FOREIGN KEY`, to add.
     public var tableConstraints: [SQLExpression]
     
+    /// A subquery which, when present, is used to fill in the contents of the new table.
+    public var asQuery: SQLExpression?
+    
     /// Creates a new `SQLCreateTable` query.
     public init(name: SQLExpression) {
         self.table = name
@@ -28,6 +31,7 @@ public struct SQLCreateTable: SQLExpression {
         self.ifNotExists = false
         self.columns = []
         self.tableConstraints = []
+        self.asQuery = nil
     }
     
     public func serialize(to serializer: inout SQLSerializer) {
@@ -47,6 +51,10 @@ public struct SQLCreateTable: SQLExpression {
             // There's no reason not to have a space between the table name and its definitions, but not
             // having it is the established behavior, which the tests check for.
             $0.append(SQLList([self.table, SQLGroupExpression(self.columns + self.tableConstraints)], separator: SQLRaw("")))
+            if let asQuery = self.asQuery {
+                $0.append("AS")
+                $0.append(asQuery)
+            }
         }
     }
 }

--- a/Tests/SQLKitTests/Async/AsyncSQLKitTests.swift
+++ b/Tests/SQLKitTests/Async/AsyncSQLKitTests.swift
@@ -657,6 +657,22 @@ CREATE TABLE `planets`(`id` BIGINT, `name` TEXT, `diameter` INTEGER, `galaxy_nam
         XCTAssertEqual(db.results[2], "CREATE TABLE `planets3`(`galaxy_id` BIGINT, FOREIGN KEY (`galaxy_id`) REFERENCES `galaxies` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE)")
     }
 
+    func testCreateTableAsSelectQuery() async throws {
+        try await db.create(table: "normalized_planet_names")
+            .column("id", type: .bigint, .primaryKey(autoIncrement: false), .notNull)
+            .column("name", type: .text, .unique, .notNull)
+            .select { $0
+                .distinct()
+                .column("id", as: "id")
+                .column(SQLFunction("LOWER", args: SQLColumn("name")), as: "name")
+                .from("planets")
+                .where("galaxy_id", .equal, SQLBind(1))
+            }
+            .run()
+            
+        XCTAssertEqual(db.results[0], "CREATE TABLE `normalized_planet_names`(`id` BIGINT PRIMARY KEY NOT NULL, `name` TEXT UNIQUE NOT NULL) AS SELECT DISTINCT `id` AS `id`, LOWER(`name`) AS `name` FROM `planets` WHERE `galaxy_id` = ?")
+    }
+
     func testSQLRowDecoder() async throws {
         struct Foo: Codable {
             let id: UUID

--- a/Tests/SQLKitTests/Async/AsyncSQLKitTests.swift
+++ b/Tests/SQLKitTests/Async/AsyncSQLKitTests.swift
@@ -197,6 +197,11 @@ final class AsyncSQLKitTests: XCTestCase {
         XCTAssertEqual(db.results[19], "DROP INDEX `planets_name_idx` RESTRICT")
     }
 
+    func testDropTemporary() async throws {
+        try await db.drop(table: "normalized_planet_names").temporary().run()
+        XCTAssertEqual(db.results[0], "DROP TEMPORARY TABLE `normalized_planet_names`")
+    }
+
     func testAltering() async throws {
         // SINGLE
         try await db.alter(table: "alterable")

--- a/Tests/SQLKitTests/Async/AsyncSQLKitTests.swift
+++ b/Tests/SQLKitTests/Async/AsyncSQLKitTests.swift
@@ -13,6 +13,8 @@ final class AsyncSQLKitTests: XCTestCase {
         self.db = TestDatabase()
     }
     
+    // MARK: Basic Queries
+    
     func testSelect_tableAllCols() async throws {
         try await db.select().column(table: "planets", column: "*")
             .from("planets")
@@ -82,6 +84,8 @@ final class AsyncSQLKitTests: XCTestCase {
         XCTAssertEqual(db.results[0], "DELETE FROM `planets` WHERE `name` = ?")
     }
     
+    // MARK: Locking Clauses
+    
     func testLockingClause_forUpdate() async throws {
         try await db.select().column("*")
             .from("planets")
@@ -100,6 +104,8 @@ final class AsyncSQLKitTests: XCTestCase {
         XCTAssertEqual(db.results[0], "SELECT * FROM `planets` WHERE `name` = ? LOCK IN SHARE MODE")
     }
     
+    // MARK: Group By/Having
+    
     func testGroupByHaving() async throws {
         try await db.select().column("*")
             .from("planets")
@@ -108,6 +114,8 @@ final class AsyncSQLKitTests: XCTestCase {
             .run()
         XCTAssertEqual(db.results[0], "SELECT * FROM `planets` GROUP BY `color` HAVING `color` = ?")
     }
+
+    // MARK: Dialect-Specific Behaviors
 
     func testIfExists() async throws {
         try await db.drop(table: "planets").ifExists().run()
@@ -234,6 +242,8 @@ final class AsyncSQLKitTests: XCTestCase {
         XCTAssertEqual(db.results[6], "ALTER TABLE `alterable` ADD `hello` TEXT , DROP `there` , MODIFY `again` TEXT")
     }
     
+    // MARK: Distinct
+    
     func testDistinct() async throws {
         try await db.select().column("*")
             .from("planets")
@@ -259,6 +269,8 @@ final class AsyncSQLKitTests: XCTestCase {
             .run()
         XCTAssertEqual(db.results[0], "SELECT COUNT(DISTINCT(`name`, `color`)) FROM `planets`")
     }
+    
+    // MARK: Joins
     
     func testSimpleJoin() async throws {
         try await db.select().column("*")
@@ -286,6 +298,8 @@ final class AsyncSQLKitTests: XCTestCase {
         XCTAssertEqual(db.results[0], "SELECT * FROM `planets` OUTER JOIN (SELECT `name` FROM `stars` WHERE `orion` = `please space`) AS `star` ON `moons`.`planet_id` IS NOT %%%%%% WHERE NULL")
     }
     
+    // MARK: Operators
+    
     func testBinaryOperators() async throws {
         try await db
             .update("planets")
@@ -301,6 +315,8 @@ final class AsyncSQLKitTests: XCTestCase {
         
         XCTAssertEqual(db.results[0], "UPDATE `planets` SET `moons` = `moons` + 1 WHERE `best_at_space` >= ?")
     }
+
+    // MARK: Returning
 
     func testReturning() async throws {
         try await db.insert(into: "planets")
@@ -321,6 +337,8 @@ final class AsyncSQLKitTests: XCTestCase {
             .all()
         XCTAssertEqual(db.results[2], "DELETE FROM `planets` RETURNING *")
     }
+    
+    // MARK: Upsert
     
     func testUpsert() async throws {
         // Test the thoroughly underpowered and inconvenient MySQL syntax first
@@ -380,6 +398,8 @@ final class AsyncSQLKitTests: XCTestCase {
         XCTAssertEqual(db.results[7], "INSERT INTO `jumpgates` (`id`, `serial_number`, `star_id`, `last_known_status`) VALUES (DEFAULT, ?, ?, ?) ON CONFLICT (`serial_number`) DO UPDATE SET `last_known_status` = ?, `star_id` = EXCLUDED.`star_id`")
         XCTAssertEqual(db.results[8], "INSERT INTO `jumpgates` (`id`, `serial_number`, `star_id`, `last_known_status`) VALUES (DEFAULT, ?, ?, ?) ON CONFLICT (`id`) DO UPDATE SET `last_known_status` = ? WHERE `last_known_status` <> ?")
     }
+
+    // MARK: Codable Nullity
 
     func testCodableWithNillableColumnWithSomeValue() async throws {
         struct Gas: Codable {
@@ -673,6 +693,8 @@ CREATE TABLE `planets`(`id` BIGINT, `name` TEXT, `diameter` INTEGER, `galaxy_nam
         XCTAssertEqual(db.results[0], "CREATE TABLE `normalized_planet_names`(`id` BIGINT PRIMARY KEY NOT NULL, `name` TEXT UNIQUE NOT NULL) AS SELECT DISTINCT `id` AS `id`, LOWER(`name`) AS `name` FROM `planets` WHERE `galaxy_id` = ?")
     }
 
+    // MARK: Row Decoder
+    
     func testSQLRowDecoder() async throws {
         struct Foo: Codable {
             let id: UUID

--- a/Tests/SQLKitTests/Async/AsyncSQLKitTriggerTests.swift
+++ b/Tests/SQLKitTests/Async/AsyncSQLKitTriggerTests.swift
@@ -1,0 +1,99 @@
+#if compiler(>=5.5) && canImport(_Concurrency)
+#if !os(Linux)
+import SQLKit
+import SQLKitBenchmark
+import XCTest
+
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+final class AsyncSQLKitTriggerTests: XCTestCase {
+    private let body = [
+        "IF NEW.amount < 0 THEN",
+        "SET NEW.amount = 0;",
+        "END IF;",
+    ]
+
+    private var db: TestDatabase!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        self.db = TestDatabase()
+    }
+
+    private func bodyText() -> String {
+        body.joined(separator: " ")
+    }
+
+    func testDropTriggerOptions() async throws {
+        var dialect = GenericDialect()
+        dialect.setTriggerSyntax(drop: [.supportsCascade, .supportsTableName])
+        debugPrint(dialect.triggerSyntax.drop)
+        db._dialect = dialect
+
+        try await db.drop(trigger: "foo").table("planets").run()
+        XCTAssertEqual(db.results.popLast(), "DROP TRIGGER `foo` ON `planets`")
+
+        try await db.drop(trigger: "foo").table("planets").ifExists().run()
+        XCTAssertEqual(db.results.popLast(), "DROP TRIGGER IF EXISTS `foo` ON `planets`")
+
+        try await db.drop(trigger: "foo").table("planets").ifExists().cascade().run()
+        XCTAssertEqual(db.results.popLast(), "DROP TRIGGER IF EXISTS `foo` ON `planets` CASCADE")
+
+        db._dialect.supportsIfExists = false
+        try await db.drop(trigger: "foo").table("planets").ifExists().run()
+        XCTAssertEqual(db.results.popLast(), "DROP TRIGGER `foo` ON `planets`")
+
+        db._dialect.triggerSyntax.drop = .supportsCascade
+        try await db.drop(trigger: "foo").table("planets").run()
+        XCTAssertEqual(db.results.popLast(), "DROP TRIGGER `foo`")
+
+        db._dialect.triggerSyntax.drop = []
+        try await db.drop(trigger: "foo").table("planets").ifExists().cascade().run()
+        XCTAssertEqual(db.results.popLast(), "DROP TRIGGER `foo`")
+    }
+
+    func testMySqlTriggerCreates() async throws {
+        var dialect = GenericDialect()
+        dialect.setTriggerSyntax(create: [.supportsBody, .requiresForEachRow, .supportsOrder])
+
+        db._dialect = dialect
+
+        try await db.create(trigger: "foo", table: "planet", when: .before, event: .insert)
+            .body(body)
+            .order(precedence: .precedes, otherTriggerName: "other")
+            .run()
+        XCTAssertEqual(db.results.popLast(), "CREATE TRIGGER `foo` BEFORE INSERT ON `planet` FOR EACH ROW PRECEDES `other` BEGIN \(bodyText()) END;")
+    }
+
+    func testSqliteTriggerCreates() async throws {
+        var dialect = GenericDialect()
+        dialect.setTriggerSyntax(create: [.supportsBody, .supportsCondition])
+        db._dialect = dialect
+
+        try await db.create(trigger: "foo", table: "planet", when: .before, event: .insert)
+            .body(body)
+            .condition("foo = bar")
+            .run()
+        XCTAssertEqual(db.results.popLast(), "CREATE TRIGGER `foo` BEFORE INSERT ON `planet` WHEN foo = bar BEGIN \(bodyText()) END;")
+    }
+
+    func testPostgreSqlTriggerCreates() async throws {
+        var dialect = GenericDialect()
+        dialect.setTriggerSyntax(create: [.supportsForEach, .postgreSQLChecks, .supportsCondition, .conditionRequiresParentheses, .supportsConstraints])
+
+        db._dialect = dialect
+
+        try await db.create(trigger: "foo", table: "planet", when: .after, event: .insert)
+            .each(.row)
+            .isConstraint()
+            .timing(.initiallyDeferred)
+            .condition("foo = bar")
+            .procedure("qwer")
+            .referencedTable(SQLIdentifier("galaxies"))
+            .run()
+
+        XCTAssertEqual(db.results.popLast(), "CREATE CONSTRAINT TRIGGER `foo` AFTER INSERT ON `planet` FROM `galaxies` INITIALLY DEFERRED FOR EACH ROW WHEN (foo = bar) EXECUTE PROCEDURE `qwer`")
+    }
+}
+
+#endif
+#endif

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -201,6 +201,11 @@ final class SQLKitTests: XCTestCase {
         try db.drop(index: "planets_name_idx").restrict().run().wait()
         XCTAssertEqual(db.results[19], "DROP INDEX `planets_name_idx` RESTRICT")
     }
+    
+    func testDropTemporary() throws {
+        try db.drop(table: "normalized_planet_names").temporary().run().wait()
+        XCTAssertEqual(db.results[0], "DROP TEMPORARY TABLE `normalized_planet_names`")
+    }
 
     func testAltering() throws {
         // SINGLE


### PR DESCRIPTION
Adds SQLKit support for creating tables populated by `SELECT` queries:

```swift
try await sqlDatabase.create(table: "populated")
    .column("id", type: .bigint, .primaryKey, .notNull)
    .column("data", type: .text)
    .select { $0
        .column(SQLLiteral.default, as: "id")
        .column(SQLFunction("UPPER", args:
            SQLFunction("LTRIM", args: SQLColumn("data"))
        ), as: "data")
        .from("original_table")
        .where("id", .in, Array(1 ... 10))
    }
    .run()
```
```sql
CREATE TABLE "populated" (
    "id" BIGINT PRIMARY KEY GENERATED BY DEFAULT AS IDENTITY NOT NULL,
    "data" TEXT
) AS SELECT
    DEFAULT AS "id",
    UPPER(LTRIM("data")) AS "data"
FROM
    "original_table"
WHERE
    "id" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
```

Additional changes:

- Significant internal reorganization of SQLKit, specifically in `SQLSelectBuilder`.
- The `.where()`, `.orWhere()`, `.having()`, and `.orHaving()` families of methods on `SQLSelectBuilder` (and other `SQLPredicateBuilders`) have been normalized so that all four sets of methods offer the same series of overloads as all the others.
- More `async` tests.
- Support for MySQL's `DROP TEMPORARY TABLE` syntax, as `sqlDatabase.drop(table: "table").temporary()`.

Note: Despite what may seem appearances to the contrary, the public API of `SQLSelectBuilder` has not lost any methods, though it has gained a small number of overloads. A concerted effort was made to avoid changing any existing API in any source-incompatible way.