### PR TITLE
Fix Swift compiler choosing wrong overload for SQLInsertBuilder.values(Encodable)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,6 @@ jobs:
     steps:
       - name: Install SQLite dependencies
         run: apt-get -q update && apt-get -q install -y libsqlite3-dev
-        if: ${{ contains(matrix.dependent, 'sqlite') }}
 
       - name: Check out sql-kit
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,79 +1,123 @@
 name: test
 on:
   pull_request:
-  push: { branches: [ main ] }
-defaults: { run: { shell: bash } }
+
 jobs:
-  sql-kit_all:
+  linux-all:
     strategy:
       fail-fast: false
       matrix:
-        image:
-          - swift:5.2-focal
-          - swift:5.3-focal
-          - swift:5.4-focal
-          - swiftlang/swift:nightly-5.5-focal
-          - swiftlang/swift:nightly-main-focal
-        include:
-          - { os: 'ubuntu-latest' }
-          - { os: 'macos-latest', image: '', xcode: 'latest' }
-          - { os: 'macos-latest', image: '', xcode: 'latest-stable' }
-    runs-on: ${{ matrix.os }}
-    container: ${{ matrix.image }}
-    steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ${{ matrix.image }}
-        if: ${{ matrix.os == 'macos-latest' }}
-      - uses: actions/checkout@v2
-      - run: swift test --enable-test-discovery --sanitize=thread
-  driver-integration_linux:
+        swiftver:
+          - swift:5.2
+          - swift:5.3
+          - swift:5.4
+          - swift:5.5
+          - swiftlang/swift:nightly-main
+        swiftos:
+          - focal
+    container: ${{ format('{0}-{1}', matrix.swiftver, matrix.swiftos) }}
     runs-on: ubuntu-latest
-    container: swift:5.4-focal
-    services:
-      psql:
-        image: postgres:latest
-        env: { POSTGRES_DB: vapor_database, POSTGRES_USER: vapor_username, POSTGRES_PASSWORD: vapor_password }
-      mysql:
-        image: mysql:latest
-        env: { MYSQL_ALLOW_EMPTY_PASSWORD: true, MYSQL_DATABASE: vapor_database, MYSQL_USER: vapor_username, MYSQL_PASSWORD: vapor_password }
     env:
-      POSTGRES_HOSTNAME: psql
-      MYSQL_HOSTNAME: mysql
-      MYSQL_TLS: true
+      LOG_LEVEL: debug
     steps:
-      - run: apt update -q && apt install -y libsqlite3-dev
-      - uses: actions/checkout@v2
+      - name: Check out package
+        uses: actions/checkout@v2
+      - name: Run tests with Thread Sanitizer
+        run: swift test --enable-test-discovery --sanitize=thread
+
+  macos-all:
+    strategy:
+      fail-fast: false
+      matrix:
+        xcode:
+          - latest-stable
+          - latest
+    runs-on: macos-11
+    env:
+      LOG_LEVEL: debug
+    steps:
+      - name: Select latest available Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.xcode }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run tests and Thread Sanitizer
+        run: |
+          swift test --enable-test-discovery ${{ matrix.filter }} --sanitize=thread \
+            -Xlinker -rpath \
+            -Xlinker $(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx
+
+  driver-integration:
+    services:
+      mysql-a:
+        image: mysql:latest
+        env: { MYSQL_ALLOW_EMPTY_PASSWORD: "true", MYSQL_USER: vapor_username, MYSQL_PASSWORD: vapor_password, MYSQL_DATABASE: vapor_database }
+      mysql-b:
+        image: mysql:latest
+        env: { MYSQL_ALLOW_EMPTY_PASSWORD: "true", MYSQL_USER: vapor_username, MYSQL_PASSWORD: vapor_password, MYSQL_DATABASE: vapor_database }
+      postgres-a:
+        image: postgres:latest
+        env: { POSTGRES_USER: vapor_username, POSTGRES_PASSWORD: vapor_password, POSTGRES_DB: vapor_database }
+      postgres-b:
+        image: postgres:latest
+        env: { POSTGRES_USER: vapor_username, POSTGRES_PASSWORD: vapor_password, POSTGRES_DB: vapor_database }
+    strategy:
+      fail-fast: false
+      matrix:
+        swiftver:
+          - swift:5.2
+          - swift:5.5
+        swiftos:
+          - focal
+    runs-on: ubuntu-latest
+    container: ${{ format('{0}-{1}', matrix.swiftver, matrix.swiftos) }}
+    env:
+      LOG_LEVEL: debug
+      POSTGRES_HOSTNAME_A: postgres-a
+      POSTGRES_USER_A: vapor_username
+      POSTGRES_PASSWORD_A: vapor_password
+      POSTGRES_DB_A: vapor_database
+      POSTGRES_HOSTNAME_B: postgres-b
+      POSTGRES_USER_B: vapor_username
+      POSTGRES_PASSWORD_B: vapor_password
+      POSTGRES_DB_B: vapor_database
+      MYSQL_HOSTNAME_A: mysql-a
+      MYSQL_USERNAME_A: vapor_username
+      MYSQL_PASSWORD_A: vapor_password
+      MYSQL_DATABASE_A: vapor_database
+      MYSQL_HOSTNAME_B: mysql-b
+      MYSQL_USERNAME_B: vapor_username
+      MYSQL_PASSWORD_B: vapor_password
+      MYSQL_DATABASE_B: vapor_database
+    steps:
+      - name: Install SQLite dependencies
+        run: apt-get -q update && apt-get -q install -y libsqlite3-dev
+        if: ${{ contains(matrix.dependent, 'sqlite') }}
+
+      - name: Check out sql-kit
+        uses: actions/checkout@v2
         with: { path: sql-kit }
-      - uses: actions/checkout@v2
-        with: { repository: 'vapor/fluent-kit', path: fluent-kit }
-      - uses: actions/checkout@v2
-        with: { repository: 'vapor/sqlite-kit', path: sqlite-kit }
-      - uses: actions/checkout@v2
+      - name: Check out fluent-sqlite-driver
+        uses: actions/checkout@v2
         with: { repository: 'vapor/fluent-sqlite-driver', path: fluent-sqlite-driver }
-      - uses: actions/checkout@v2
-        with: { repository: 'vapor/postgres-kit', path: postgres-kit }
-      - uses: actions/checkout@v2
+      - name: Check out fluent-postgres-driver
+        uses: actions/checkout@v2
         with: { repository: 'vapor/fluent-postgres-driver', path: fluent-postgres-driver }
-      - uses: actions/checkout@v2
-        with: { repository: 'vapor/mysql-kit', path: mysql-kit }
-      - uses: actions/checkout@v2
+      - name: Check out fluent-mysql-driver
+        uses: actions/checkout@v2
         with: { repository: 'vapor/fluent-mysql-driver', path: fluent-mysql-driver }
-      - run: |
-          for p in {fluent,sqlite,postgres,mysql}-kit fluent-{sqlite,postgres,mysql}-driver; do
-            swift package --package-path $p edit sql-kit --path sql-kit
-          done      
-      - run: swift test --package-path fluent-kit --enable-test-discovery --sanitize=thread
-        continue-on-error: true
-      - run: swift test --package-path sqlite-kit --enable-test-discovery --sanitize=thread
-        continue-on-error: true
-      - run: swift test --package-path fluent-sqlite-driver --enable-test-discovery --sanitize=thread
-        continue-on-error: true
-      - run: swift test --package-path postgres-kit --enable-test-discovery --sanitize=thread
-        continue-on-error: true
-      - run: swift test --package-path fluent-postgres-driver --enable-test-discovery --sanitize=thread
-        continue-on-error: true
-      - run: swift test --package-path mysql-kit --enable-test-discovery --sanitize=thread
-        continue-on-error: true
-      - run: swift test --package-path fluent-mysql-driver --enable-test-discovery --sanitize=thread
-        continue-on-error: true
+
+      - name: Use sql-kit in fluent-sqlite-driver
+        run: swift package --package-path fluent-sqlite-driver edit sql-kit --path sql-kit
+      - name: Use sql-kit in fluent-postgres-driver
+        run: swift package --package-path fluent-postgres-driver edit sql-kit --path sql-kit
+      - name: Use sql-kit in fluent-myql-driver
+        run: swift package --package-path fluent-mysql-driver edit sql-kit --path sql-kit
+        
+      - name: Run fluent-sqlite-driver tests with Thread Sanitizer
+        run: swift test --package-path fluent-sqlite-driver --enable-test-discovery --sanitize=thread
+      - name: Run fluent-postgres-driver tests with Thread Sanitizer
+        run: swift test --package-path fluent-postgres-driver --enable-test-discovery --sanitize=thread
+      - name: Run fluent-mysql-driver tests with Thread Sanitizer
+        run: swift test --package-path fluent-mysql-driver --enable-test-discovery --sanitize=thread

--- a/Sources/SQLKit/Builders/SQLInsertBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLInsertBuilder.swift
@@ -90,6 +90,7 @@ public final class SQLInsertBuilder: SQLQueryBuilder, SQLReturningBuilder {
     }
     
     @discardableResult
+    @_disfavoredOverload
     public func values(_ values: Encodable...) -> Self {
         let row: [SQLExpression] = values.map(SQLBind.init)
         self.insert.values.append(row)

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -304,6 +304,19 @@ final class SQLKitTests: XCTestCase {
         
         XCTAssertEqual(db.results[0], "UPDATE `planets` SET `moons` = `moons` + 1 WHERE `best_at_space` >= ?")
     }
+    
+    func testInsertWithArrayOfEncodable() throws {
+        func weird<S: Sequence>(_ builder: SQLInsertBuilder, values: S) -> SQLInsertBuilder where S.Element: Encodable {
+            builder.values(Array(values))
+        }
+        
+        try weird(db.insert(into: "planets")
+            .columns("name")
+            , values: ["Jupiter"])
+            .run().wait()
+        XCTAssertEqual(db.results[0], "INSERT INTO `planets` (`name`) VALUES (?)")
+        XCTAssertEqual(db.bindResults[0] as? [String], ["Jupiter"]) // instead of [["Jupiter"]]
+    }
 
     func testReturning() throws {
         try db.insert(into: "planets")

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -311,9 +311,9 @@ final class SQLKitTests: XCTestCase {
         }
         
         try weird(db.insert(into: "planets")
-            .columns("name")
-            , values: ["Jupiter"])
-            .run().wait()
+            .columns("name"),
+            values: ["Jupiter"]
+        ).run().wait()
         XCTAssertEqual(db.results[0], "INSERT INTO `planets` (`name`) VALUES (?)")
         XCTAssertEqual(db.bindResults[0] as? [String], ["Jupiter"]) // instead of [["Jupiter"]]
     }

--- a/Tests/SQLKitTests/Utilities.swift
+++ b/Tests/SQLKitTests/Utilities.swift
@@ -5,6 +5,7 @@ final class TestDatabase: SQLDatabase {
     let logger: Logger
     let eventLoop: EventLoop
     var results: [String]
+    var bindResults: [[Encodable]]
     var dialect: SQLDialect {
         self._dialect
     }
@@ -14,6 +15,7 @@ final class TestDatabase: SQLDatabase {
         self.logger = .init(label: "codes.vapor.sql.test")
         self.eventLoop = EmbeddedEventLoop()
         self.results = []
+        self.bindResults = []
         self._dialect = GenericDialect()
     }
     
@@ -21,6 +23,7 @@ final class TestDatabase: SQLDatabase {
         var serializer = SQLSerializer(database: self)
         query.serialize(to: &serializer)
         results.append(serializer.sql)
+        bindResults.append(serializer.binds)
         return self.eventLoop.makeSucceededFuture(())
     }
 }


### PR DESCRIPTION
Under certain specific circumstances, the Swift compiler will choose the wrong overload of `SQLInsertBuilder.values(_:)` for the variants that take `Encodable` (specifically when an explicit Array is used in a generic context). Since it's too late to fix the API (it's public now), adding @_disfavoredOverload works around the issue in what should be a backwards-compatible fashion.