### PR TITLE
Adds `LIMIT`, `OFFSET` and `ORDER BY` to Union results

### DIFF
--- a/Sources/SQLKit/Builders/SQLPartialResultBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLPartialResultBuilder.swift
@@ -1,0 +1,72 @@
+
+public protocol SQLPartialResultBuilder: AnyObject {
+    /// Zero or more `ORDER BY` clauses.
+    var orderBys: [SQLExpression] { get set }
+
+    /// If set, limits the maximum number of results.
+    var limit: Int? { get set }
+    
+    /// If set, offsets the results.
+    var offset: Int? { get set }
+}
+
+// MARK: - Limit/offset
+
+extension SQLPartialResultBuilder {
+    /// Adds a `LIMIT` clause to the query. If called more than once, the last call wins.
+    ///
+    /// - Parameter max: Optional maximum limit. If `nil`, any existing limit is removed.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func limit(_ max: Int?) -> Self {
+        self.limit = max
+        return self
+    }
+
+    /// Adds a `OFFSET` clause to the query. If called more than once, the last call wins.
+    ///
+    /// - Parameter max: Optional offset. If `nil`, any existing offset is removed.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func offset(_ n: Int?) -> Self {
+        self.offset = n
+        return self
+    }
+}
+
+// MARK: - Order
+
+extension SQLPartialResultBuilder {
+    /// Adds an `ORDER BY` clause to the query with the specified column and ordering.
+    ///
+    /// - Parameters:
+    ///   - column: Name of column to sort results by. Appended to any previously added orderings.
+    ///   - direction: The sort direction for the column.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func orderBy(_ column: String, _ direction: SQLDirection = .ascending) -> Self {
+        return self.orderBy(SQLColumn(column), direction)
+    }
+
+
+    /// Adds an `ORDER BY` clause to the query with the specifed expression and ordering.
+    ///
+    /// - Parameters:
+    ///   - expression: Expression to sort results by. Appended to any previously added orderings.
+    ///   - direction: An expression describing the sort direction for the ordering expression.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func orderBy(_ expression: SQLExpression, _ direction: SQLExpression) -> Self {
+        return self.orderBy(SQLOrderBy(expression: expression, direction: direction))
+    }
+
+    /// Adds an `ORDER BY` clause to the query using the specified expression.
+    ///
+    /// - Parameter expression: Expression to sort results by. Appended to any previously added orderings.
+    /// - Returns: `self` for chaining.
+    @discardableResult
+    public func orderBy(_ expression: SQLExpression) -> Self {
+        orderBys.append(expression)
+        return self
+    }
+}

--- a/Sources/SQLKit/Builders/SQLSubqeryClauseBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLSubqeryClauseBuilder.swift
@@ -10,7 +10,7 @@
 /// - Note: The primary motivation for the existence of this protocol is to make it easier
 ///   to construct `SELECT` queries without specifying a database or providing the
 ///   `SQLQueryBuilder` and `SQLQueryFetcher` methods in inappropriate contexts.
-public protocol SQLSubqueryClauseBuilder: SQLJoinBuilder, SQLPredicateBuilder, SQLSecondaryPredicateBuilder {
+public protocol SQLSubqueryClauseBuilder: SQLJoinBuilder, SQLPredicateBuilder, SQLSecondaryPredicateBuilder, SQLPartialResultBuilder {
     var select: SQLSelect { get set }
 }
 
@@ -32,6 +32,23 @@ extension SQLSubqueryClauseBuilder {
     public var secondaryPredicate: SQLExpression? {
         get { return self.select.having }
         set { self.select.having = newValue }
+    }
+}
+
+extension SQLSubqueryClauseBuilder {
+    public var orderBys: [SQLExpression] {
+        get { self.select.orderBy }
+        set { self.select.orderBy = newValue }
+    }
+    
+    public var limit: Int? {
+        get { self.select.limit }
+        set { self.select.limit = newValue }
+    }
+    
+    public var offset: Int? {
+        get { self.select.offset }
+        set { self.select.offset = newValue }
     }
 }
 
@@ -220,30 +237,6 @@ extension SQLSubqueryClauseBuilder {
     }
 }
 
-// MARK: - Limit/offset
-
-extension SQLSubqueryClauseBuilder {
-    /// Adds a `LIMIT` clause to the query. If called more than once, the last call wins.
-    ///
-    /// - Parameter max: Optional maximum limit. If `nil`, any existing limit is removed.
-    /// - Returns: `self` for chaining.
-    @discardableResult
-    public func limit(_ max: Int?) -> Self {
-        self.select.limit = max
-        return self
-    }
-
-    /// Adds a `OFFSET` clause to the query. If called more than once, the last call wins.
-    ///
-    /// - Parameter max: Optional offset. If `nil`, any existing offset is removed.
-    /// - Returns: `self` for chaining.
-    @discardableResult
-    public func offset(_ n: Int?) -> Self {
-        self.select.offset = n
-        return self
-    }
-}
-
 // MARK: - Group By
 
 extension SQLSubqueryClauseBuilder {
@@ -263,43 +256,6 @@ extension SQLSubqueryClauseBuilder {
     @discardableResult
     public func groupBy(_ expression: SQLExpression) -> Self {
         self.select.groupBy.append(expression)
-        return self
-    }
-}
-
-// MARK: - Order
-
-extension SQLSubqueryClauseBuilder {
-    /// Adds an `ORDER BY` clause to the query with the specified column and ordering.
-    ///
-    /// - Parameters:
-    ///   - column: Name of column to sort results by. Appended to any previously added orderings.
-    ///   - direction: The sort direction for the column.
-    /// - Returns: `self` for chaining.
-    @discardableResult
-    public func orderBy(_ column: String, _ direction: SQLDirection = .ascending) -> Self {
-        return self.orderBy(SQLColumn(column), direction)
-    }
-
-
-    /// Adds an `ORDER BY` clause to the query with the specifed expression and ordering.
-    ///
-    /// - Parameters:
-    ///   - expression: Expression to sort results by. Appended to any previously added orderings.
-    ///   - direction: An expression describing the sort direction for the ordering expression.
-    /// - Returns: `self` for chaining.
-    @discardableResult
-    public func orderBy(_ expression: SQLExpression, _ direction: SQLExpression) -> Self {
-        return self.orderBy(SQLOrderBy(expression: expression, direction: direction))
-    }
-
-    /// Adds an `ORDER BY` clause to the query using the specified expression.
-    ///
-    /// - Parameter expression: Expression to sort results by. Appended to any previously added orderings.
-    /// - Returns: `self` for chaining.
-    @discardableResult
-    public func orderBy(_ expression: SQLExpression) -> Self {
-        select.orderBy.append(expression)
         return self
     }
 }

--- a/Sources/SQLKit/Builders/SQLUnionBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLUnionBuilder.swift
@@ -1,4 +1,4 @@
-public final class SQLUnionBuilder: SQLQueryBuilder, SQLQueryFetcher {
+public final class SQLUnionBuilder: SQLQueryBuilder, SQLQueryFetcher, SQLPartialResultBuilder {
     public var query: SQLExpression { self.union }
 
     public var union: SQLUnion
@@ -37,6 +37,23 @@ public final class SQLUnionBuilder: SQLQueryBuilder, SQLQueryFetcher {
     public func except(all query: SQLSelect) -> Self {
         self.union.add(query, joiner: .init(type: .exceptAll))
        return self
+    }
+}
+
+extension SQLUnionBuilder {
+    public var orderBys: [SQLExpression] {
+        get { self.union.orderBys }
+        set { self.union.orderBys = newValue }
+    }
+    
+    public var limit: Int? {
+        get { self.union.limit }
+        set { self.union.limit = newValue }
+    }
+    
+    public var offset: Int? {
+        get { self.union.offset }
+        set { self.union.offset = newValue }
     }
 }
 

--- a/Sources/SQLKit/Query/SQLUnion.swift
+++ b/Sources/SQLKit/Query/SQLUnion.swift
@@ -1,10 +1,22 @@
 public struct SQLUnion: SQLExpression {
     public var initialQuery: SQLSelect
     public var unions: [(SQLUnionJoiner, SQLSelect)]
+    
+    /// Zero or more `ORDER BY` clauses.
+    public var orderBys: [SQLExpression]
+    
+    /// If set, limits the maximum number of results.
+    public var limit: Int?
+    
+    /// If set, offsets the results.
+    public var offset: Int?
 
     public init(initialQuery: SQLSelect, unions: [(SQLUnionJoiner, SQLSelect)] = []) {
         self.initialQuery = initialQuery
         self.unions = unions
+        self.limit = nil
+        self.offset = nil
+        self.orderBys = []
     }
 
     public mutating func add(_ query: SQLSelect, all: Bool) {
@@ -33,6 +45,19 @@ public struct SQLUnion: SQLExpression {
             self.unions.forEach { joiner, query in
                 statement.append(joiner)
                 appendQuery(query)
+            }
+            
+            if !self.orderBys.isEmpty {
+                statement.append("ORDER BY")
+                statement.append(SQLList(self.orderBys))
+            }
+            if let limit = self.limit {
+                statement.append("LIMIT")
+                statement.append(limit.description)
+            }
+            if let offset = self.offset {
+                statement.append("OFFSET")
+                statement.append(offset.description)
             }
         }
     }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

Previously it was not easy to do pagination on the result of `SELECT ... UNION queries`. For example:

```sql
(SELECT * FROM "Table" WHERE "name" = 'first thing')
UNION ALL
(SELECT * FROM "Zone" WHERE "name" = 'second thing')
LIMIT 5
OFFSET 3
ORDER BY "name"
``` 

This pull request adds `LIMIT`, `OFFSET`, and `ORDER BY` functionality to the `SQLUnion`/`SQLUnionBuilder`, primarily by copying over the `SQLSelect` and `SQLSubqueryClauseBuilder` implementations.

I also have a protocol-based approach that reduces code copying but it comes with it's own smells. I'm happy to elaborate if desired.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
