### PR TITLE
UNION handles single entry

### DIFF
--- a/Sources/SQLKit/Query/SQLUnion.swift
+++ b/Sources/SQLKit/Query/SQLUnion.swift
@@ -16,7 +16,9 @@ public struct SQLUnion: SQLExpression {
     }
 
     public func serialize(to serializer: inout SQLSerializer) {
-        assert(!self.unions.isEmpty, "Serializing a union with only one query is invalid.")
+        guard !self.unions.isEmpty else {
+            return initialQuery.serialize(to: &serializer)
+        }
 
         serializer.statement { statement in
             func appendQuery(_ query: SQLSelect) {

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -906,5 +906,11 @@ CREATE TABLE `planets`(`id` BIGINT, `name` TEXT, `diameter` INTEGER, `galaxy_nam
               .run().wait()
 
         XCTAssertEqual(db.results[17], "(SELECT `id` FROM `t1`) UNION DISTINCT (SELECT `id` FROM `t2`) UNION ALL (SELECT `id` FROM `t3`) INTERSECT DISTINCT (SELECT `id` FROM `t4`) INTERSECT ALL (SELECT `id` FROM `t5`) EXCEPT DISTINCT (SELECT `id` FROM `t6`) EXCEPT ALL (SELECT `id` FROM `t7`)")
+        
+        // Test that having a single entry in the union just executes that entry
+        try db.union { select in
+            select.column("id").from("t1")
+        }.run().wait()
+        XCTAssertEqual(db.results[18], "SELECT `id` FROM `t1`")
     }
 }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

This PR simplifies dynamically building UNION statements.

To be specific, it loosens the restriction that a SQLUnion must contain multiple select statements. While this is common usage, it makes building up `UNION`s in client code difficult. For example, building up a UNION in a for loop is awkward right now:

```swift
let ids = [1, 2, 3, ...]
guard let firstId = ids.first else { ... }

// Must manually short-circuit as a SQLSelectBuilder
guard ids.count > 1 else {
    return sql.select.column("id").from("t1").where("id", .equals, firstId).all()
}
let unionBuilder = sql.union { select in
    select.column("id").from("t1").where("id", .equals, firstId)
}
for id in ids[1..<ids.count] {
    unionBuilder.union(all: { select in
        select.column("id").from("t1").where("id", .equals, id)
    })
}
return unionBuilder.all()
```

This PR removes the need for the commented `guard` in the code above. It also improves code safety by removing a runtime fatal error condition.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
