### PR TITLE
Adds multirow insert method

### DIFF
--- a/Sources/SQLKit/Builders/Implementations/SQLInsertBuilder.swift
+++ b/Sources/SQLKit/Builders/Implementations/SQLInsertBuilder.swift
@@ -283,6 +283,16 @@ public final class SQLInsertBuilder: SQLQueryBuilder, SQLReturningBuilder/*, SQL
         self.insert.values.append(values)
         return self
     }
+
+    /// Add multiple sequences of values each inserted as a separate row.
+    @inlinable
+    @discardableResult
+    public func rows<S1, S2>(_ valueSets: S1) -> Self
+        where S1: Sequence, S2: Sequence,
+              S1.Element == S2, S2.Element == any SQLExpression
+    {
+        valueSets.reduce(self) { $0.values(Array($1)) }
+    }
     
     /// Specify a `SELECT` query to generate rows to insert.
     ///

--- a/Tests/SQLKitTests/SQLInsertUpsertTests.swift
+++ b/Tests/SQLKitTests/SQLInsertUpsertTests.swift
@@ -44,88 +44,88 @@ final class SQLInsertUpsertTests: XCTestCase {
 
     func testInsertValuesEncodable() throws {
         // Test variadic values method
-        try db.insert(into: "planets")
-            .columns(["name", "color"])
-            .values("Jupiter", "orange")
-            .run().wait()
-        XCTAssertEqual(db.results[0], "INSERT INTO ``planets`` (``name``, ``color``) VALUES (&1, &2)")
-        XCTAssertEqual(db.bindResults[0] as? [String], ["Jupiter", "orange"])
+        XCTAssertSerialization(
+            of: self.db.insert(into: "planets")
+                .columns(["name", "color"])
+                .values("Jupiter", "orange"),
+            is: "INSERT INTO ``planets`` (``name``, ``color``) VALUES (&1, &2)"
+        )
         
         // Test array values method
-        try db.insert(into: "planets")
-            .columns(["name", "color"])
-            .values(["Jupiter", "orange"])
-            .run().wait()
-        XCTAssertEqual(db.results[1], "INSERT INTO ``planets`` (``name``, ``color``) VALUES (&1, &2)")
-        XCTAssertEqual(db.bindResults[1] as? [String], ["Jupiter", "orange"])
-        
+        XCTAssertSerialization(
+            of: db.insert(into: "planets")
+                .columns(["name", "color"])
+                .values(["Jupiter", "orange"]),
+            is: "INSERT INTO ``planets`` (``name``, ``color``) VALUES (&1, &2)"
+        )
+
         // Test nested array values method
-        try db.insert(into: "planets")
-            .columns(["name", "color"])
-            .values([["Jupiter", "orange"],["Mars", "red"]])
-            .run().wait()
-        XCTAssertEqual(db.results[2], "INSERT INTO ``planets`` (``name``, ``color``) VALUES (&1, &2)")
-        XCTAssertEqual(db.bindResults[2] as? [[String]], [["Jupiter", "orange"], ["Mars", "red"]])
+        XCTAssertSerialization(
+            of: db.insert(into: "planets")
+                .columns(["name", "color"])
+                .values([["Jupiter", "orange"],["Mars", "red"]]),
+            is: "INSERT INTO ``planets`` (``name``, ``color``) VALUES (&1, &2)"
+        )
         
         // Test multiple values calls make multiple rows
-        try db.insert(into: "planets")
-            .columns(["name", "color"])
-            .values(["Jupiter", "orange"])
-            .values(["Mars", "red"])
-            .run().wait()
-        XCTAssertEqual(db.results[3], "INSERT INTO ``planets`` (``name``, ``color``) VALUES (&1, &2), (&3, &4)")
-        XCTAssertEqual(db.bindResults[3] as? [String], ["Jupiter", "orange", "Mars", "red"])
+        XCTAssertSerialization(
+            of: self.db.insert(into: "planets")
+                .columns(["name", "color"])
+                .values(["Jupiter", "orange"])
+                .values(["Mars", "red"]),
+            is: "INSERT INTO ``planets`` (``name``, ``color``) VALUES (&1, &2), (&3, &4)"
+        )
         
         // Test single-value input method
-        try db.insert(into: "planets")
-            .columns(["name"])
-            .values(["Jupiter"])
-            .run().wait()
-        XCTAssertEqual(db.results[4], "INSERT INTO ``planets`` (``name``) VALUES (&1)")
-        XCTAssertEqual(db.bindResults[4] as? [String], ["Jupiter"])
+        XCTAssertSerialization(
+            of: self.db.insert(into: "planets")
+                .columns(["name"])
+                .values(["Jupiter"]),
+            is: "INSERT INTO ``planets`` (``name``) VALUES (&1)"
+        )
     }
     
     func testInsertValuesExpression() throws {
         // Test variadic values method
-        try db.insert(into: "planets")
-            .columns(["name", "color"])
-            .values(SQLBind("Jupiter"), SQLBind("orange"))
-            .run().wait()
-        XCTAssertEqual(db.results[0], "INSERT INTO ``planets`` (``name``, ``color``) VALUES (&1, &2)")
-        XCTAssertEqual(db.bindResults[0] as? [String], ["Jupiter", "orange"])
+        XCTAssertSerialization(
+            of: self.db.insert(into: "planets")
+                .columns(["name", "color"])
+                .values(SQLBind("Jupiter"), SQLBind("orange")),
+            is: "INSERT INTO ``planets`` (``name``, ``color``) VALUES (&1, &2)"
+        )
 
         // Test array values method
-        try db.insert(into: "planets")
-            .columns(["name", "color"])
-            .values([SQLBind("Jupiter"), SQLBind("orange")])
-            .run().wait()
-        XCTAssertEqual(db.results[1], "INSERT INTO ``planets`` (``name``, ``color``) VALUES (&1, &2)")
-        XCTAssertEqual(db.bindResults[1] as? [String], ["Jupiter", "orange"])
+        XCTAssertSerialization(
+            of: self.db.insert(into: "planets")
+                .columns(["name", "color"])
+                .values([SQLBind("Jupiter"), SQLBind("orange")]),
+            is: "INSERT INTO ``planets`` (``name``, ``color``) VALUES (&1, &2)"
+        )
 
         // Test nested array values method
-        try db.insert(into: "planets")
-            .columns(["name", "color"])
-            .rows([[SQLBind("Jupiter"), SQLBind("orange")],[SQLBind("Mars"), SQLBind("red")]])
-            .run().wait()
-        XCTAssertEqual(db.results[2], "INSERT INTO ``planets`` (``name``, ``color``) VALUES (&1, &2), (&3, &4)")
-        XCTAssertEqual(db.bindResults[2] as? [String], ["Jupiter", "orange", "Mars", "red"])
+        XCTAssertSerialization(
+            of: self.db.insert(into: "planets")
+                .columns(["name", "color"])
+                .rows([[SQLBind("Jupiter"), SQLBind("orange")],[SQLBind("Mars"), SQLBind("red")]]),
+            is: "INSERT INTO ``planets`` (``name``, ``color``) VALUES (&1, &2), (&3, &4)"
+        )
 
         // Test multiple values calls make multiple rows
-        try db.insert(into: "planets")
-            .columns(["name", "color"])
-            .values(["Jupiter", "orange"])
-            .values([SQLBind("Mars"), SQLBind("red")])
-            .run().wait()
-        XCTAssertEqual(db.results[3], "INSERT INTO ``planets`` (``name``, ``color``) VALUES (&1, &2), (&3, &4)")
-        XCTAssertEqual(db.bindResults[3] as? [String], ["Jupiter", "orange", "Mars", "red"])
+        XCTAssertSerialization(
+            of: self.db.insert(into: "planets")
+                .columns(["name", "color"])
+                .values(["Jupiter", "orange"])
+                .values([SQLBind("Mars"), SQLBind("red")]),
+            is: "INSERT INTO ``planets`` (``name``, ``color``) VALUES (&1, &2), (&3, &4)"
+        )
 
         // Test single-value input method
-        try db.insert(into: "planets")
-            .columns(["name"])
-            .values([SQLBind("Jupiter")])
-            .run().wait()
-        XCTAssertEqual(db.results[4], "INSERT INTO ``planets`` (``name``) VALUES (&1)")
-        XCTAssertEqual(db.bindResults[4] as? [String], ["Jupiter"])
+        XCTAssertSerialization(
+            of: self.db.insert(into: "planets")
+                .columns(["name"])
+                .values([SQLBind("Jupiter")]),
+            is: "INSERT INTO ``planets`` (``name``) VALUES (&1)"
+        )
     }
     
     // MARK: - Upsert


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

This adds functionality to do a multi-row inserts with a single `values` method call.

Previously, to insert multiple rows a user had to call `values` repeatedly:

```swift
db.insert(into: "planets")
    .columns(["name", "color"])
    .values([SQLBind("Jupiter"), SQLBind("orange")])
    .values([SQLBind("Mars"), SQLBind("red")])
    .run()
```

This was a bit awkward when inserting rows from an array, where an instance of the builder had to be saved off and edited:

```swift
let rows: [[SQLExpression]]  = [[...], [...], ...]
let builder = db.insert(into: "planets")
    .columns(["name", "color"])
for row in rows {
    builder.values(row)
}
builder.run()
```

This MR simplifies the mutli-row insert situation by adding a `values` method overload that accepts a nested array:

```swift
db.insert(into: "planets")
    .columns(["name", "color"])
    .values([[SQLBind("Jupiter"), SQLBind("orange")], [SQLBind("Mars"), SQLBind("red")]])
    .run()

let rows  = [[...], [...], ...]
db.insert(into: "planets")
    .columns(["name", "color"])
    .values(rows)
    .run()
```

### NOTE

This functionality was only added to the `SQLExpression` version of `values`, NOT the `Encodable` version of `values`. There are known issues with `[Encodable]` conforming to `Encodable` that prevent adequate type checks.

For example, if a `values(_ rows: [[Encodable]])` is defined, it is undeterministic since the same call would also match `values(_ rows: [Encodable])`. If instead we change `values(_ rows: [Encodable])` to detect `[[Encodable]]` cases at runtime, then it is difficult to guarantee that a caller hasn't mixed `Encodable` and `[Encodable]` values.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
