### PR TITLE
Add support for varying syntax of SELECT locking clauses.

### DIFF
--- a/Sources/SQLKit/Builders/SQLSubqeryClauseBuilder.swift
+++ b/Sources/SQLKit/Builders/SQLSubqeryClauseBuilder.swift
@@ -267,28 +267,35 @@ extension SQLSubqueryClauseBuilder {
     ///
     /// ```swift
     /// db.select()...for(.update)
+    /// db.select()...for(.share)
     /// ```
     ///
-    /// Also called locking reads, the `SELECT ... FOR UPDATE` syntax locks all selected rows
-    /// for the duration of the current transaction. How the rows are locked depends on the
-    /// specific expression supplied and the underlying database implementation.
+    /// Also referred to as locking or "consistent" reads, the locking clause syntax locks
+    /// all selected rows for the duration of the current transaction with a type of lock
+    /// determined by the specific locking clause and the underlying database's support for
+    /// this construct.
     ///
-    /// - Parameter lockingClause: The type of lock to obtain.
+    /// - Warning: If the database in use does not support locking reads, the locking clause
+    ///   will be silently ignored regardless of its value.
+    ///
+    /// - Parameter lockingClause: The type of lock to obtain. See ``SQLLockingClause``.
     /// - Returns: `self` for chaining.
     @discardableResult
     public func `for`(_ lockingClause: SQLLockingClause) -> Self {
         return self.lockingClause(lockingClause)
     }
 
-    /// Adds a locking clause to this query. If called more than once, the last call wins.
+    /// Adds a locking clause to this query as specified by an arbitrary ``SQLExpression``.
+    /// If called more than once, the last call wins.
     ///
     /// ```swift
     /// db.select()...lockingClause(...)
     /// ```
     ///
-    /// Also called locking reads, the `SELECT ... FOR UPDATE` syntax locks all selected rows
-    /// for the duration of the current transaction. How the rows are locked depends on the
-    /// specific expression supplied and the underlying database implementation.
+    /// Also referred to as locking or "consistent" reads, the locking clause syntax locks
+    /// all selected rows for the duration of the current transaction with a type of lock
+    /// determined by the specific locking clause and the underlying database's support for
+    /// this construct.
     ///
     /// - Note: This method allows providing an arbitrary SQL expression as the locking clause.
     ///

--- a/Sources/SQLKit/Query/SQLLockingClause.swift
+++ b/Sources/SQLKit/Query/SQLLockingClause.swift
@@ -1,22 +1,23 @@
-/// General locking expressions for a SQL locking clause.
+/// General locking expressions for a SQL locking clause. The actual locking clause syntax
+/// for any given SQL dialect is defined by the dialect.
 ///
 ///     SELECT ... FOR UPDATE
 ///
-/// See `SQLSelectBuilder.for` and `SQLSelect.lockingClause`.
+/// See ``SQLSubqueryClauseBuilder/for(_:)`` and ``SQLSelect/lockingClause``.
 public enum SQLLockingClause: SQLExpression {
-    /// `UPDATE`
+    /// Request an exclusive "writer" lock.
     case update
     
-    /// `SHARE`
+    /// Request a shared "reader" lock.
     case share
     
-    /// See `SQLExpression`.
+    /// See ``SQLExpression/serialize(to:)``.
     public func serialize(to serializer: inout SQLSerializer) {
-        switch self {
-        case .share:
-            serializer.write("FOR SHARE")
-        case .update:
-            serializer.write("FOR UPDATE")
+        serializer.statement {
+            switch self {
+            case .share: $0.append($0.dialect.sharedSelectLockExpression)
+            case .update: $0.append($0.dialect.exclusiveSelectLockExpression)
+            }
         }
     }
 }

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -155,6 +155,17 @@ public protocol SQLDialect {
     ///
     /// Defaults to `[.union, .unionAll]`.
     var unionFeatures: SQLUnionFeatures { get }
+    
+    /// A serialization for ``SQLLockingClause/share``, representing a request for a shared "reader"
+    /// lock on rows retrieved by a `SELECT` query. A `nil` value means the database doesn't
+    /// support shared locking requests, which causes the locking clause to be silently ignored.
+    var sharedSelectLockExpression: SQLExpression? { get }
+    
+    /// A serialization for ``SQLLockingClause/update``, representing a request for an exclusive
+    /// "writer" lock on rows retrieved by a `SELECT` query. A `nil` value means the database doesn't
+    /// support exclusive locking requests, which causes the locking clause to be silently ignored.
+    var exclusiveSelectLockExpression: SQLExpression? { get }
+    
 }
 
 /// Controls `ALTER TABLE` syntax.
@@ -309,4 +320,6 @@ extension SQLDialect {
     public func normalizeSQLConstraint(identifier: SQLExpression) -> SQLExpression { identifier }
     public var upsertSyntax: SQLUpsertSyntax { .unsupported }
     public var unionFeatures: SQLUnionFeatures { [.union, .unionAll] }
+    public var sharedSelectLockExpression: SQLExpression? { nil }
+    public var exclusiveSelectLockExpression: SQLExpression? { nil }
 }

--- a/Sources/SQLKit/SQLStatement.swift
+++ b/Sources/SQLKit/SQLStatement.swift
@@ -36,6 +36,11 @@ public struct SQLStatement: SQLExpression {
     public mutating func append(_ part: SQLExpression) {
         self.parts.append(part)
     }
+    
+    /// Add an ``SQLExpression`` of any kind to the output, but only if it isn't `nil`.
+    public mutating func append(_ maybePart: SQLExpression?) {
+        maybePart.map { self.append($0) }
+    }
 
     // See `SQLSerializer.serialize(to:)`.
     public func serialize(to serializer: inout SQLSerializer) {

--- a/Tests/SQLKitTests/Async/AsyncSQLKitTests.swift
+++ b/Tests/SQLKitTests/Async/AsyncSQLKitTests.swift
@@ -106,7 +106,16 @@ final class AsyncSQLKitTests: XCTestCase {
         XCTAssertEqual(db.results[0], "SELECT * FROM `planets` WHERE `name` = ? FOR UPDATE")
     }
     
-    func testLockingClause_lockInShareMode() async throws {
+    func testLockingClause_forShare() async throws {
+        try await db.select().column("*")
+            .from("planets")
+            .where("name", .equal, "Earth")
+            .for(.share)
+            .run()
+        XCTAssertEqual(db.results[0], "SELECT * FROM `planets` WHERE `name` = ? FOR SHARE")
+    }
+    
+    func testLockingClause_raw() async throws {
         try await db.select().column("*")
             .from("planets")
             .where("name", .equal, "Earth")

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -112,7 +112,16 @@ final class SQLKitTests: XCTestCase {
         XCTAssertEqual(db.results[0], "SELECT * FROM `planets` WHERE `name` = ? FOR UPDATE")
     }
     
-    func testLockingClause_lockInShareMode() throws {
+    func testLockingClause_forShare() throws {
+        try db.select().column("*")
+            .from("planets")
+            .where("name", .equal, "Earth")
+            .for(.share)
+            .run().wait()
+        XCTAssertEqual(db.results[0], "SELECT * FROM `planets` WHERE `name` = ? FOR SHARE")
+    }
+    
+    func testLockingClause_raw() throws {
         try db.select().column("*")
             .from("planets")
             .where("name", .equal, "Earth")

--- a/Tests/SQLKitTests/Utilities.swift
+++ b/Tests/SQLKitTests/Utilities.swift
@@ -85,6 +85,8 @@ struct GenericDialect: SQLDialect {
     var alterTableSyntax = SQLAlterTableSyntax(alterColumnDefinitionClause: SQLRaw("MODIFY"), alterColumnDefinitionTypeKeyword: nil)
     var upsertSyntax: SQLUpsertSyntax = .standard
     var unionFeatures: SQLUnionFeatures = []
+    var sharedSelectLockExpression: SQLExpression? { SQLRaw("FOR SHARE") }
+    var exclusiveSelectLockExpression: SQLExpression? { SQLRaw("FOR UPDATE") }
 
     mutating func setTriggerSyntax(create: SQLTriggerSyntax.Create = [], drop: SQLTriggerSyntax.Drop = []) {
         self.triggerSyntax.create = create


### PR DESCRIPTION
The `FOR SHARE` syntax previously provided by adding `.for(.share)` to a `SELECT` query is specific to PostgreSQL. This update allows each database driver to specify the correct syntax for locking clauses - or to signal that it doesn't implement that functionality - via its `SQLDialect`. The default is to assume locking clauses are not supported.

Because new public API is added to `SQLStatement` and `SQLDialect`, this update is `semver-minor`.

PR for MySQL support: vapor/mysql-kit#310
PR for PostgreSQL support: vapor/postgres-kit#230
PR for SQLite support: <not required, SQLite does not support locking clauses>