### PR TITLE
Add configuration option for dialects without multi row insert support

### DIFF
--- a/Sources/SQLKit/Query/SQLInsert.swift
+++ b/Sources/SQLKit/Query/SQLInsert.swift
@@ -30,6 +30,10 @@ public struct SQLInsert: SQLExpression {
     
     public func serialize(to serializer: inout SQLSerializer) {
         let modifier = self.conflictStrategy?.queryModifier(for: serializer)
+
+        if !serializer.dialect.supportsMultiRowInsert && self.values.count > 1 {
+            serializer.database.logger.warning("Database does not support inserting multiple row in a single statement. You will need to rewrite as individual insert statements.")
+        }
         
         serializer.statement {
             $0.append("INSERT")

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -165,7 +165,14 @@ public protocol SQLDialect {
     /// "writer" lock on rows retrieved by a `SELECT` query. A `nil` value means the database doesn't
     /// support exclusive locking requests, which causes the locking clause to be silently ignored.
     var exclusiveSelectLockExpression: SQLExpression? { get }
-    
+
+    /// `true` if the dialect supports inserting multiple rows with a single statement. If `false`,
+    /// the dialect requires separate statements for each insert.
+    ///
+    ///     INSERT INTO table(col1, col2) VALUES (val1, val2), (val3, val4)
+    ///
+    /// Defaults to `true`.
+    var supportsMultiRowInsert: Bool { get }
 }
 
 /// Controls `ALTER TABLE` syntax.
@@ -322,4 +329,5 @@ extension SQLDialect {
     public var unionFeatures: SQLUnionFeatures { [.union, .unionAll] }
     public var sharedSelectLockExpression: SQLExpression? { nil }
     public var exclusiveSelectLockExpression: SQLExpression? { nil }
+    public var supportsMultiRowInsert: Bool { true }
 }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
This change adds a configuration parameter (`SQLDialect.supportsMultiRowInsert`) to support dialects that do not support multi row inserts (e.g. Oracle). This is `true` by default. If `false`, a warning will be logged once multiple rows are about to be inserted into the database within a single statement.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
