### PR TITLE
Add support for nested subpath (JSON) expressions

### DIFF
--- a/Sources/SQLKit/Query/SQLDataType.swift
+++ b/Sources/SQLKit/Query/SQLDataType.swift
@@ -6,6 +6,7 @@ public enum SQLDataType: SQLExpression {
     case text
     case real
     case blob
+    case json
     case custom(any SQLExpression)
 
     @available(*, deprecated, message: "This is a test utility method that was incorrectly made public. Use `.custom()` directly instead.")
@@ -27,6 +28,7 @@ public enum SQLDataType: SQLExpression {
             case .text:            sql = SQLRaw("TEXT")
             case .real:            sql = SQLRaw("REAL")
             case .blob:            sql = SQLRaw("BLOB")
+            case .json:            sql = SQLRaw("JSON")
             case .custom(let exp): sql = exp
             }
         }

--- a/Sources/SQLKit/Query/SQLDataType.swift
+++ b/Sources/SQLKit/Query/SQLDataType.swift
@@ -6,7 +6,6 @@ public enum SQLDataType: SQLExpression {
     case text
     case real
     case blob
-    case json
     case custom(any SQLExpression)
 
     @available(*, deprecated, message: "This is a test utility method that was incorrectly made public. Use `.custom()` directly instead.")
@@ -28,7 +27,6 @@ public enum SQLDataType: SQLExpression {
             case .text:            sql = SQLRaw("TEXT")
             case .real:            sql = SQLRaw("REAL")
             case .blob:            sql = SQLRaw("BLOB")
-            case .json:            sql = SQLRaw("JSON")
             case .custom(let exp): sql = exp
             }
         }

--- a/Sources/SQLKit/Query/SQLNestedSubpathExpression.swift
+++ b/Sources/SQLKit/Query/SQLNestedSubpathExpression.swift
@@ -1,0 +1,21 @@
+/// Represents a "nested subpath" expression. At this time, this always represents a key path leading to a
+/// specific value in a JSON object.
+public struct SQLNestedSubpathExpression: SQLExpression {
+    public var column: any SQLExpression
+    public var path: [String]
+    
+    public init(column: any SQLExpression, path: [String]) {
+        assert(!path.isEmpty)
+        
+        self.column = column
+        self.path = path
+    }
+    
+    public init(column: String, path: [String]) {
+        self.init(column: SQLIdentifier(column), path: path)
+    }
+
+    public func serialize(to serializer: inout SQLSerializer) {
+        serializer.dialect.nestedSubpathExpression(in: self.column, for: self.path)?.serialize(to: &serializer)
+    }
+}

--- a/Sources/SQLKit/SQLDialect.swift
+++ b/Sources/SQLKit/SQLDialect.swift
@@ -166,6 +166,13 @@ public protocol SQLDialect {
     /// support exclusive locking requests, which causes the locking clause to be silently ignored.
     var exclusiveSelectLockExpression: (any SQLExpression)? { get }
     
+    /// Given a column name and a path consisting of one or more elements, assume the column is of
+    /// JSON type and return an appropriate expression for accessing the value at the given JSON
+    /// path, according to the semantics of the dialect. Return `nil` if JSON subpath expressions
+    /// are not supported or the given path is not valid in the dialect.
+    ///
+    /// Defaults to returning `nil`.
+    func nestedSubpathExpression(in column: any SQLExpression, for path: [String]) -> (any SQLExpression)?
 }
 
 /// Controls `ALTER TABLE` syntax.
@@ -323,4 +330,5 @@ extension SQLDialect {
     public var unionFeatures: SQLUnionFeatures { [.union, .unionAll] }
     public var sharedSelectLockExpression: (any SQLExpression)? { nil }
     public var exclusiveSelectLockExpression: (any SQLExpression)? { nil }
+    public func nestedSubpathExpression(in column: any SQLExpression, for path: [String]) -> (any SQLExpression)? { nil }
 }

--- a/Sources/SQLKitBenchmark/SQLBenchmark+JSONPaths.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmark+JSONPaths.swift
@@ -1,0 +1,47 @@
+import SQLKit
+import XCTest
+
+extension SQLBenchmarker {
+    public func testJSONPaths() throws {
+        try self.runTest {
+            try $0.drop(table: "planet_metadata")
+                .ifExists()
+                .run().wait()
+            try $0.create(table: "planet_metadata")
+                .column("id", type: .bigint, .primaryKey(autoIncrement: true))
+                .column("metadata", type: .json)
+                .run().wait()
+
+            // insert
+            try $0.insert(into: "planet_metadata")
+                .columns("id", "metadata")
+                .values(SQLLiteral.default, SQLLiteral.string(#"{"a":{"b":{"c":[1,2,3]}}}"#))
+                .run().wait()
+            
+            // try to extract fields
+            let objectARows = try $0.select().column(SQLNestedSubpathExpression(column: "metadata", path: ["a"]), as: "data").from("planet_metadata").all().wait()
+            let objectARow = try XCTUnwrap(objectARows.first)
+            let objectARaw = try objectARow.decode(column: "data", as: String.self)
+            let objectA = try JSONDecoder().decode([String: [String: [Int]]].self, from: objectARaw.data(using: .utf8)!)
+            
+            XCTAssertEqual(objectARows.count, 1)
+            XCTAssertEqual(objectA, ["b": ["c": [1, 2 ,3]]])
+            
+            let objectBRows = try $0.select().column(SQLNestedSubpathExpression(column: "metadata", path: ["a", "b"]), as: "data").from("planet_metadata").all().wait()
+            let objectBRow = try XCTUnwrap(objectBRows.first)
+            let objectBRaw = try objectBRow.decode(column: "data", as: String.self)
+            let objectB = try JSONDecoder().decode([String: [Int]].self, from: objectBRaw.data(using: .utf8)!)
+            
+            XCTAssertEqual(objectBRows.count, 1)
+            XCTAssertEqual(objectB, ["c": [1, 2, 3]])
+
+            let objectCRows = try $0.select().column(SQLNestedSubpathExpression(column: "metadata", path: ["a", "b", "c"]), as: "data").from("planet_metadata").all().wait()
+            let objectCRow = try XCTUnwrap(objectCRows.first)
+            let objectCRaw = try objectCRow.decode(column: "data", as: String.self)
+            let objectC = try JSONDecoder().decode([Int].self, from: objectCRaw.data(using: .utf8)!)
+            
+            XCTAssertEqual(objectCRows.count, 1)
+            XCTAssertEqual(objectC, [1, 2, 3])
+        }
+    }
+}

--- a/Sources/SQLKitBenchmark/SQLBenchmark+JSONPaths.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmark+JSONPaths.swift
@@ -9,7 +9,7 @@ extension SQLBenchmarker {
                 .run().wait()
             try $0.create(table: "planet_metadata")
                 .column("id", type: .bigint, .primaryKey(autoIncrement: $0.dialect.supportsAutoIncrement))
-                .column("metadata", type: .json)
+                .column("metadata", type: .custom(SQLRaw($0.dialect.name == "postgresql" ? "jsonb" : "json")))
                 .run().wait()
 
             // insert

--- a/Sources/SQLKitBenchmark/SQLBenchmark+JSONPaths.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmark+JSONPaths.swift
@@ -8,7 +8,7 @@ extension SQLBenchmarker {
                 .ifExists()
                 .run().wait()
             try $0.create(table: "planet_metadata")
-                .column("id", type: .bigint, .primaryKey(autoIncrement: true))
+                .column("id", type: .bigint, .primaryKey(autoIncrement: $0.dialect.supportsAutoIncrement))
                 .column("metadata", type: .json)
                 .run().wait()
 

--- a/Sources/SQLKitBenchmark/SQLBenchmarker.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmarker.swift
@@ -15,6 +15,7 @@ public final class SQLBenchmarker {
         if self.database.dialect.name != "generic" {
             try self.testUpserts()
             try self.testUnions()
+            try self.testJSONPaths()
         }
     }
     

--- a/Tests/SQLKitTests/SQLKitTests.swift
+++ b/Tests/SQLKitTests/SQLKitTests.swift
@@ -966,4 +966,15 @@ CREATE TABLE `planets`(`id` BIGINT, `name` TEXT, `diameter` INTEGER, `galaxy_nam
             .wait()
         XCTAssertEqual(db.results[20], "(SELECT * FROM `t1`) UNION (SELECT * FROM `t2`) ORDER BY `id` ASC, `name` DESC")
     }
+    
+    func testJSONPaths() throws {
+        try db.select()
+            .column(SQLNestedSubpathExpression(column: "json", path: ["a"]))
+            .column(SQLNestedSubpathExpression(column: "json", path: ["a", "b"]))
+            .column(SQLNestedSubpathExpression(column: "json", path: ["a", "b", "c"]))
+            .column(SQLNestedSubpathExpression(column: SQLColumn("json", table: "table"), path: ["a", "b"]))
+            .run()
+            .wait()
+        XCTAssertEqual(db.results[0], "SELECT (`json`->>'a'), (`json`->'a'->>'b'), (`json`->'a'->'b'->>'c'), (`table`.`json`->'a'->>'b')")
+    }
 }

--- a/Tests/SQLKitTests/Utilities.swift
+++ b/Tests/SQLKitTests/Utilities.swift
@@ -87,6 +87,11 @@ struct GenericDialect: SQLDialect {
     var unionFeatures: SQLUnionFeatures = []
     var sharedSelectLockExpression: (any SQLExpression)? { SQLRaw("FOR SHARE") }
     var exclusiveSelectLockExpression: (any SQLExpression)? { SQLRaw("FOR UPDATE") }
+    func nestedSubpathExpression(in column: SQLExpression, for path: [String]) -> (SQLExpression)? {
+        precondition(!path.isEmpty)
+        let descender = SQLList([column] + path.dropLast().map(SQLLiteral.string(_:)), separator: SQLRaw("->"))
+        return SQLGroupExpression(SQLList([descender, SQLLiteral.string(path.last!)], separator: SQLRaw("->>")))
+    }
 
     mutating func setTriggerSyntax(create: SQLTriggerSyntax.Create = [], drop: SQLTriggerSyntax.Drop = []) {
         self.triggerSyntax.create = create


### PR DESCRIPTION
Adds a new (defaulted) `SQLDialect` method for correctly generating JSON subpath syntax on a per-dialect basis. Add `SQLNestedSubpathExpression` to enable actually invoking the method.

Related PRs for `PostgresKit`, `MySQLKit`, and `SQLiteKit` will be forthcoming, followed by a series of PRs against `FluentKit`, `FluentPostgresDriver`, `FluentMySQLDriver`, and `FluentSQLiteDriver`. (Yep, gotta update _everything_ to properly leverage this, thanks to it having been handled incorrectly all this time!)