### PR TITLE
Revert the changed package name in the exports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,22 @@ jobs:
   unit-tests:
     uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
 
+  pure-fluent-integration-test:
+    if: ${{ !(github.event.pull_request.draft || false) }}
+    runs-on: ubuntu-latest
+    container: swift-5.10:jammy
+    steps:
+      - name: Check out sql-kit
+        uses: actions/checkout@v4
+        with: { path: sql-kit, repository: vapor/sql-kit }
+      - name: Check out fluent-kit
+        uses: actions/checkout@v4
+        with: { path: fluent-kit, repository: vapor/fluent-kit }
+      - name: Set up and run FluentKit tests
+        run: |
+          swift package --package-path fluent-kit edit --path sql-kit sql-kit
+          swift test --package-path fluent-kit --sanitize=thread
+  
   integration-tests:
     if: ${{ !(github.event.pull_request.draft || false) }}
     services:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
   pure-fluent-integration-test:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift-5.10:jammy
+    container: swift:5.10-jammy
     steps:
       - name: Check out sql-kit
         uses: actions/checkout@v4

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,7 @@ let package = Package(
             name: "SQLKit",
             dependencies: [
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "Collections", package: "swift-collections"),
             ],

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(
@@ -49,6 +49,7 @@ let package = Package(
 )
 
 var swiftSettings: [SwiftSetting] { [
+    .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("ConciseMagicFile"),
     .enableUpcomingFeature("ForwardTrailingClosures"),
     .enableUpcomingFeature("ImportObjcForwardDeclarations"),

--- a/Sources/SQLKit/Exports.swift
+++ b/Sources/SQLKit/Exports.swift
@@ -1,3 +1,3 @@
-@_documentation(visibility: internal) @_exported import protocol NIOCore.EventLoop
-@_documentation(visibility: internal) @_exported import class NIOCore.EventLoopFuture
+@_documentation(visibility: internal) @_exported import protocol NIO.EventLoop
+@_documentation(visibility: internal) @_exported import class NIO.EventLoopFuture
 @_documentation(visibility: internal) @_exported import struct Logging.Logger


### PR DESCRIPTION
This apparently broke building against FluentKit when not using any of the driver packages. Also add CI to test this scenario.