### PR TITLE
fix: Adds back-support for SQLBind public API

### DIFF
--- a/Sources/SQLKit/Expressions/Syntax/SQLBind.swift
+++ b/Sources/SQLKit/Expressions/Syntax/SQLBind.swift
@@ -8,10 +8,23 @@ public struct SQLBind: SQLExpression {
     public init(_ encodable: some Encodable & Sendable) {
         self.encodable = encodable
     }
+
+    /// Create a binding to a value.
+    @inlinable
+    @_disfavoredOverload
+    public init(_ encodable: any Encodable & Sendable) {
+        self.encodable = encodable
+    }
     
     /// Create a list of bindings to an array of values, with the placeholders wrapped in an ``SQLGroupExpression``.
     @inlinable
     public static func group(_ items: some Collection<some Encodable & Sendable>) -> any SQLExpression {
+        SQLGroupExpression(items.map(SQLBind.init))
+    }
+
+    /// Create a list of bindings to an array of values, with the placeholders wrapped in an ``SQLGroupExpression``.
+    @inlinable
+    public static func group(_ items: [any Encodable & Sendable]) -> any SQLExpression {
         SQLGroupExpression(items.map(SQLBind.init))
     }
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

This restores the public API of `SQLBind`. It appears that the `any Encodable` argument support was dropped between v3.28.0 and v3.29.0.

Please let me know if you'd like these functions marked as `Deprecated` and placed in the `Deprecated` source directory.

Thanks for all your work on this package!!

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
