### PR TITLE
Fix overhaul breakage, part 2

### DIFF
--- a/Sources/SQLKit/Builders/Prototypes/SQLColumnUpdateBuilder.swift
+++ b/Sources/SQLKit/Builders/Prototypes/SQLColumnUpdateBuilder.swift
@@ -76,7 +76,7 @@ extension SQLColumnUpdateBuilder {
     ///   - bind: The value to assign to the named column.
     @inlinable
     @discardableResult
-    public func set(_ column: String, to bind: some Encodable & Sendable) -> Self {
+    public func set(_ column: String, to bind: any Encodable & Sendable) -> Self {
         self.set(SQLColumn(column), to: SQLBind(bind))
     }
     
@@ -102,7 +102,7 @@ extension SQLColumnUpdateBuilder {
     ///   - bind: The value to assign to the given column.
     @inlinable
     @discardableResult
-    public func set(_ column: any SQLExpression, to bind: some Encodable & Sendable) -> Self {
+    public func set(_ column: any SQLExpression, to bind: any Encodable & Sendable) -> Self {
         self.set(column, to: SQLBind(bind))
     }
     

--- a/Sources/SQLKit/Expressions/Basics/SQLQueryString.swift
+++ b/Sources/SQLKit/Expressions/Basics/SQLQueryString.swift
@@ -118,7 +118,7 @@ extension SQLQueryString {
     ///
     /// This overload is provided as shorthand - `\(bind: "a")` is identical to `\(SQLBind("a"))`.
     @inlinable
-    public mutating func appendInterpolation(bind value: some Encodable & Sendable) {
+    public mutating func appendInterpolation(bind value: any Encodable & Sendable) {
         self.fragments.append(SQLBind(value))
     }
 

--- a/Sources/SQLKit/Expressions/Clauses/SQLColumnAssignment.swift
+++ b/Sources/SQLKit/Expressions/Clauses/SQLColumnAssignment.swift
@@ -19,13 +19,13 @@ public struct SQLColumnAssignment: SQLExpression {
     
     /// Create a column assignment from a column identifier and value binding.
     @inlinable
-    public init(setting columnName: any SQLExpression, to value: some Encodable & Sendable) {
+    public init(setting columnName: any SQLExpression, to value: any Encodable & Sendable) {
         self.init(setting: columnName, to: SQLBind(value))
     }
 
     /// Create a column assignment from a column name and value binding.
     @inlinable
-    public init(setting columnName: String, to value: some Encodable & Sendable) {
+    public init(setting columnName: String, to value: any Encodable & Sendable) {
         self.init(setting: columnName, to: SQLBind(value))
     }
 

--- a/Sources/SQLKit/Expressions/SQLSerializer.swift
+++ b/Sources/SQLKit/Expressions/SQLSerializer.swift
@@ -30,7 +30,7 @@ public struct SQLSerializer: Sendable {
     ///
     /// - Parameter encodable: The value to bind.
     @inlinable
-    public mutating func write(bind encodable: some Encodable & Sendable) {
+    public mutating func write(bind encodable: any Encodable & Sendable) {
         self.binds.append(encodable)
         self.dialect.bindPlaceholder(at: self.binds.count)
             .serialize(to: &self)

--- a/Sources/SQLKit/Expressions/Syntax/SQLBind.swift
+++ b/Sources/SQLKit/Expressions/Syntax/SQLBind.swift
@@ -5,13 +5,13 @@ public struct SQLBind: SQLExpression {
     
     /// Create a binding to a value.
     @inlinable
-    public init(_ encodable: some Encodable & Sendable) {
+    public init(_ encodable: any Encodable & Sendable) {
         self.encodable = encodable
     }
     
     /// Create a list of bindings to an array of values, with the placeholders wrapped in an ``SQLGroupExpression``.
     @inlinable
-    public static func group(_ items: some Collection<some Encodable & Sendable>) -> any SQLExpression {
+    public static func group(_ items: [any Encodable & Sendable]) -> any SQLExpression {
         SQLGroupExpression(items.map(SQLBind.init))
     }
 

--- a/Tests/SQLKitTests/TestMocks.swift
+++ b/Tests/SQLKitTests/TestMocks.swift
@@ -33,7 +33,7 @@ extension SQLQueryBuilder {
 /// A very minimal mock `SQLDatabase` which implements `execut(sql:_:)` by saving the serialized SQL and bindings to
 /// its internal arrays of accumulated "results". Most things about its dialect are mutable.
 final class TestDatabase: SQLDatabase, @unchecked Sendable {
-    let logger: Logger = .init(label: "codes.vapor.sql.test")
+    let logger: Logger = { var l = Logger(label: "codes.vapor.sql.test"); l.logLevel = .debug; return l }()
     let eventLoop: any EventLoop = FakeEventLoop()
     var results: [String] = []
     var bindResults: [[any Encodable & Sendable]] = []


### PR DESCRIPTION
This solves the source code breakage issue first reported in #175 - shout out and thanks to @NeedleInAJayStack for reporting the problem!

Several preexisting APIs had incorrectly changed from accepting `any Encodable` to accepting `some Encodable`, which is source-breaking under some conditions. This restores the original use of `any` (though it keeps the added `Sendable` requirement). 

Also restores 100% test coverage after the previous fixes.

> [!NOTE]
> Many APIs which had previously accepted a generic parameter (i.e. `<E: Encodable>`), most notably in `SQLPredicateBuilder`, also switched to using `some Encodable`, but this was not source-breaking; the problem applied only to APIs which originally accepted `any Encodable`.
>
> Although the changes in this PR are technically themselves source-breaking, since they revert a previous such breakage to its previous state, only a `semver-patch` bump is necessary.