### PR TITLE
Relax minimum dependency version for swift-collections

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.64.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
-        .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
-        .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.3.0"),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.1"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "SQLKitBenchmark", targets: ["SQLKitBenchmark"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.64.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.62.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.1"),
     ],

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -16,8 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.64.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
-        .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
-        .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.3.0"),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.1"),
     ],
     targets: [
         .target(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "SQLKitBenchmark", targets: ["SQLKitBenchmark"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.64.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.62.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.1"),
     ],


### PR DESCRIPTION
Downstream users of SQLKit who also depend on [SwiftPM](https://github.com/apple/swift-package-manager) currently experience a dependency conflict with `swift-collections` due to SwiftPM's restrictive allowed version range. Since SQLKit doesn't actually need the newest `swift-collections`, we can solve this by simply reducing SQLKit's minimum required version.

Also removes a spurious dependency on `swift-docc-plugin` which was accidentally left in place during the 3.29.0 release.