### PR TITLE
Add failing test for regression

### DIFF
--- a/Tests/SQLKitTests/SQLRowDecoderTests.swift
+++ b/Tests/SQLKitTests/SQLRowDecoderTests.swift
@@ -172,6 +172,17 @@ final class SQLRowDecoderTests: XCTestCase {
             XCTAssertEqual(Array<any CodingKey>().map(\.stringValue), context.codingPath.map(\.stringValue))
         }
     }
+    
+    func testSnakeCase_CodableKeyTransformation() throws {
+        struct Episode: Decodable, Equatable {
+            var userID: Int
+        }
+
+        XCTAssertEqual(
+            try SQLRowDecoder(keyDecodingStrategy: .convertFromSnakeCase).decode(Episode.self, from: TestRow(data: ["user_id": "1"])),
+            Episode(userID: 1)
+        )
+    }
 }
 
 enum TestDecEnum: Codable {


### PR DESCRIPTION
We have a project that started failing row decoding when upgrading from 3.28.0. I haven't dug into the problem but was able to sketch out a failing test that I believe should pass in 3.28.0 (wasn't able to easily confirm because the testing infrastructure on `main` didn't exist back then).