### PR TITLE
Resolve issues breaking Swift Wasm builds for sql-kit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
     secrets: inherit
     with:
       with_android: true
+      with_wasm: true
 
   pure-fluent-integration-test:
     if: ${{ !(github.event.pull_request.draft || false) }}

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,21 @@
 // swift-tools-version:5.10
 import PackageDescription
 
+let nonWASIPlatforms: [Platform] = [
+    .macOS,
+    .macCatalyst,
+    .iOS,
+    .tvOS,
+    .watchOS,
+    .visionOS,
+    .driverKit,
+    .linux,
+    .windows,
+    .android,
+    // .wasi, // Everything but WASI
+    .openbsd,
+]
+
 let package = Package(
     name: "sql-kit",
     platforms: [
@@ -28,6 +43,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Collections", package: "swift-collections"),
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "NIO", package: "swift-nio", condition: .when(platforms: nonWASIPlatforms)),
                 .product(name: "NIOCore", package: "swift-nio"),
             ],
             swiftSettings: swiftSettings

--- a/Package.swift
+++ b/Package.swift
@@ -16,9 +16,11 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
-        // TODO: SM: Require a minimum swift-nio version once latest nio core fixes are versionized.
-        // .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0.TBD"),
-        .package(url: "https://github.com/apple/swift-nio.git", branch: "main"),
+        // NOTE: Compiling to wasm requires specific versions of swift-nio.
+        // This older version is left as-is to avoid placing restrictions
+        // on other targets. But to compile for wasm, make sure you have
+        // a version of swift-nio with a passing build for the NIOCore module.
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -31,11 +31,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
-        // NOTE: Compiling to wasm requires specific versions of swift-nio.
-        // This older version is left as-is to avoid placing restrictions
-        // on other targets. But to compile for wasm, make sure you have
-        // a version of swift-nio with a passing build for the NIOCore module.
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.84.0"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,21 +1,6 @@
 // swift-tools-version:5.10
 import PackageDescription
 
-let nonWASIPlatforms: [Platform] = [
-    .macOS,
-    .macCatalyst,
-    .iOS,
-    .tvOS,
-    .watchOS,
-    .visionOS,
-    .driverKit,
-    .linux,
-    .windows,
-    .android,
-    // .wasi, // Everything but WASI
-    .openbsd,
-]
-
 let package = Package(
     name: "sql-kit",
     platforms: [
@@ -39,7 +24,6 @@ let package = Package(
             dependencies: [
                 .product(name: "Collections", package: "swift-collections"),
                 .product(name: "Logging", package: "swift-log"),
-                .product(name: "NIO", package: "swift-nio", condition: .when(platforms: nonWASIPlatforms)),
                 .product(name: "NIOCore", package: "swift-nio"),
             ],
             swiftSettings: swiftSettings

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,9 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
+        // TODO: SM: Require a minimum swift-nio version once latest nio core fixes are versionized.
+        // .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0.TBD"),
+        .package(url: "https://github.com/apple/swift-nio.git", branch: "main"),
     ],
     targets: [
         .target(
@@ -24,7 +26,6 @@ let package = Package(
             dependencies: [
                 .product(name: "Collections", package: "swift-collections"),
                 .product(name: "Logging", package: "swift-log"),
-                .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOCore", package: "swift-nio"),
             ],
             swiftSettings: swiftSettings

--- a/Sources/SQLKit/Exports.swift
+++ b/Sources/SQLKit/Exports.swift
@@ -1,3 +1,8 @@
+#if os(WASI)
 @_documentation(visibility: internal) @_exported import protocol NIOCore.EventLoop
 @_documentation(visibility: internal) @_exported import class NIOCore.EventLoopFuture
+#else
+@_documentation(visibility: internal) @_exported import protocol NIO.EventLoop
+@_documentation(visibility: internal) @_exported import class NIO.EventLoopFuture
+#endif
 @_documentation(visibility: internal) @_exported import struct Logging.Logger

--- a/Sources/SQLKit/Exports.swift
+++ b/Sources/SQLKit/Exports.swift
@@ -1,8 +1,3 @@
-#if os(WASI)
 @_documentation(visibility: internal) @_exported import protocol NIOCore.EventLoop
 @_documentation(visibility: internal) @_exported import class NIOCore.EventLoopFuture
-#else
-@_documentation(visibility: internal) @_exported import protocol NIO.EventLoop
-@_documentation(visibility: internal) @_exported import class NIO.EventLoopFuture
-#endif
 @_documentation(visibility: internal) @_exported import struct Logging.Logger

--- a/Sources/SQLKit/Exports.swift
+++ b/Sources/SQLKit/Exports.swift
@@ -1,3 +1,3 @@
-@_documentation(visibility: internal) @_exported import protocol NIO.EventLoop
-@_documentation(visibility: internal) @_exported import class NIO.EventLoopFuture
+@_documentation(visibility: internal) @_exported import protocol NIOCore.EventLoop
+@_documentation(visibility: internal) @_exported import class NIOCore.EventLoopFuture
 @_documentation(visibility: internal) @_exported import struct Logging.Logger


### PR DESCRIPTION
# Summary

This PR adds support for compiling sql-kit to wasm using the [Swift SDK for WebAssembly](https://www.swift.org/documentation/articles/wasm-getting-started.html).

This PR is [part of a larger effort](https://github.com/PassiveLogic/swift-web-examples/issues/1) by a company called PassiveLogic to enable broad support for Swift WebAssembly.

# Details

- Removed unused NIO dependency in Package.swift. This repo compiles fine without that, but having it breaks wasm compilation.
- Refined scope of exports to be `NIOCore` instead of the broader `NIO`.

# Notes

- Compiling to wasm requires specific versions of swift-nio. Because swift-nio still doesn't have wasm targets in it's CI, the wasm build breaks often. That issue [will be resolved soon](https://github.com/apple/swift-nio/pull/3159). Regardless, we don't want to bump the minimum nio requirement in the manifest, because that would be a breaking change for many using this repo. It is fine to leave the minimum nio requirement as-is. Developers trying to compile for wasm will almost certainly be aware of the issues compiling nio, and will soon have many wasm-compatible versions of nio to select.

# Testing done

- [x] Verified unit tests still pass with these changes
- [x] Verified `swift build` completes without errors
- [x] Verified no new compiler warnings are added with these changes
- [x] Verified `swift build --swift-sdk wasm32-unknown-wasi` completes without errors, when using a compatible nio version.
- [x] Verified `swift build --swift-sdk wasm32-unknown-wasip1-threads` completes without errors, when using a compatible nio version.
- [x] Verified a third-party executable can build this library as part of a larger wasm executable using the command `swift package --swift-sdk wasm32-unknown-wasip1-threads js --use-cdn`
- [x] Verified these changes compile in CI, using yet-to-be merged additions to vapor's CI. See See https://github.com/PassiveLogic/sql-kit/actions/runs/15886122859/job/44798410586?pr=1

# Impact Risk

There is a chance the changes to the manifest and exports could be a breaking change somewhere, if downstream dependencies relied on those pieces for their one and only intrinsic inclusion of the entire NIO dependency beyond NIOCore.

There are solutions to narrow the scope to just wasm compilation for those changes, if that is an issue. But I chose to leave them this way since it is a little cleaner solution.