### PR TITLE
ci: Enables opt-in wasm CI build for sql-kit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
     secrets: inherit
     with:
       with_android: true
+      with_wasm: true
 
   pure-fluent-integration-test:
     if: ${{ !(github.event.pull_request.draft || false) }}


### PR DESCRIPTION
⚠️  This PR is blocked from final testing and merging until dependent PR's are both merged and released. I added issues to the diff that I will resolve once everything is ready to resolve.

# Change summary

Added swift wasm as a opt-in CI target, to help prevent future breakages to swift wasm builds.

This PR is [part of a larger effort](https://github.com/PassiveLogic/swift-web-examples/issues/1) by PassiveLogic to add wasm support to many popular repositories.

# Notes

- CI for this won't pass until a future swift-nio version is ready. See details below.

# PR Dependencies

The following PR's must be merged before this PR can be merged:

- https://github.com/apple/swift-nio/pull/3271 (already merged, waiting for new swift-nio release)
- https://github.com/vapor/ci/pull/54
- https://github.com/vapor/sql-kit/pull/190

# Testing done

Verified this new workflow functions correctly using a temporary PR that enables the new wasm build.

See https://github.com/PassiveLogic/sql-kit/actions/runs/15886122859/job/44798410586?pr=1

# Remaining work

- [ ] Run tests on this once all dependent PR's are merged and released.