### PR TITLE
feat: Add Wasm platform by conditionally building without swift-nio

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,12 @@
 // swift-tools-version:6.1
 import PackageDescription
 
+/// `.when(platforms:)` can only include, never exclude, so excluding WASI means listing everything else.
+/// This list matches the [supported platforms on the Swift 6.1 release of SPM](https://github.com/swiftlang/swift-package-manager/blob/release/6.1/Sources/PackageDescription/SupportedPlatforms.swift).
+/// Don't add new platforms here unless raising the swift-tools-version of this manifest.
+let allPlatforms: [Platform] = [.macOS, .macCatalyst, .iOS, .tvOS, .watchOS, .visionOS, .driverKit, .linux, .windows, .android, .wasi, .openbsd]
+let nonWASIPlatforms: [Platform] = allPlatforms.filter { $0 != .wasi }
+
 let package = Package(
     name: "sql-kit",
     platforms: [
@@ -24,7 +30,13 @@ let package = Package(
             dependencies: [
                 .product(name: "Collections", package: "swift-collections"),
                 .product(name: "Logging", package: "swift-log"),
-                .product(name: "NIOCore", package: "swift-nio"),
+                // NIOCore itself builds for wasm32-unknown-wasip1, but the drivers beneath SQLKit
+                // cannot build SwiftNIO there (NIOPosix needs POSIX sockets and threads), so no
+                // driver on that platform could implement an `EventLoopFuture` surface. Target
+                // dependency conditions are evaluated per platform, so on WASI NIOCore is simply
+                // not linked and that surface drops out via `#if canImport(NIOCore)`; the async
+                // surface is unaffected.
+                .product(name: "NIOCore", package: "swift-nio", condition: .when(platforms: nonWASIPlatforms)),
             ],
             swiftSettings: swiftSettings
         ),
@@ -38,8 +50,9 @@ let package = Package(
         .testTarget(
             name: "SQLKitTests",
             dependencies: [
-                .product(name: "NIOCore", package: "swift-nio"),
-                .product(name: "NIOEmbedded", package: "swift-nio"),
+                // The test suite exercises the SwiftNIO surface, so it is not built for WASI.
+                .product(name: "NIOCore", package: "swift-nio", condition: .when(platforms: nonWASIPlatforms)),
+                .product(name: "NIOEmbedded", package: "swift-nio", condition: .when(platforms: nonWASIPlatforms)),
                 .target(name: "SQLKit"),
                 .target(name: "SQLKitBenchmark"),
             ],

--- a/Sources/SQLKit/Builders/Prototypes/SQLQueryBuilder.swift
+++ b/Sources/SQLKit/Builders/Prototypes/SQLQueryBuilder.swift
@@ -1,4 +1,6 @@
+#if canImport(NIOCore)
 import class NIOCore.EventLoopFuture
+#endif
 
 /// Base definitions for builders which set up queries and execute them against a given database.
 ///
@@ -10,18 +12,21 @@ public protocol SQLQueryBuilder: AnyObject {
     /// Connection to execute query on.
     var database: any SQLDatabase { get }
 
+    #if canImport(NIOCore)
     /// Execute the query on the connection, ignoring any results.
     ///
     /// Although it is a protocol requirement for historical reasons, this is considered a legacy interface
     /// thanks to its reliance on `EventLoopFuture`. Users should call ``run()-3tldd`` whenever possible.
     func run() -> EventLoopFuture<Void>
-    
+    #endif
+
     /// Execute the query on the connection, ignoring any results.
     func run() async throws
 
 }
 
 extension SQLQueryBuilder {
+    #if canImport(NIOCore)
     /// Execute the query associated with the builder on the builder's database, ignoring any results.
     ///
     /// See ``SQLQueryFetcher`` for methods which retrieve results from a query.
@@ -29,6 +34,7 @@ extension SQLQueryBuilder {
     public func run() -> EventLoopFuture<Void> {
         self.database.execute(sql: self.query) { _ in }
     }
+    #endif  // canImport(NIOCore)
 
     /// Execute the query associated with the builder on the builder's database, ignoring any results.
     ///

--- a/Sources/SQLKit/Builders/Prototypes/SQLQueryFetcher.swift
+++ b/Sources/SQLKit/Builders/Prototypes/SQLQueryFetcher.swift
@@ -1,10 +1,15 @@
+// `EventLoopFuture` is unavailable where SwiftNIO is not linked. The `async` `first()`/`all()`/
+// `run(_:)` families further down are unconditional and carry the whole surface there.
+#if canImport(NIOCore)
 import class NIOCore.EventLoopFuture
+#endif
 
 /// Common definitions for ``SQLQueryBuilder``s which support retrieving result rows.
 public protocol SQLQueryFetcher: SQLQueryBuilder {}
 
 // MARK: - First (EventLoopFuture)
 
+#if canImport(NIOCore)
 extension SQLQueryFetcher {
     /// Returns the named column from the first output row, if any, decoded as a given type.
     ///
@@ -69,6 +74,8 @@ extension SQLQueryFetcher {
         return self.run { if rows.isEmpty { rows.append($0) } }.map { rows.first }
     }
 }
+
+#endif  // canImport(NIOCore)
 
 // MARK: - First (async)
 
@@ -144,6 +151,7 @@ extension SQLQueryFetcher {
 
 // MARK: - All (EventLoopFuture)
 
+#if canImport(NIOCore)
 extension SQLQueryFetcher {
     /// Returns the named column from each output row, if any, decoded as a given type.
     ///
@@ -204,6 +212,8 @@ extension SQLQueryFetcher {
         return self.run { row in rows.append(row) }.map { rows }
     }
 }
+
+#endif  // canImport(NIOCore)
 
 // MARK: - All (async)
 
@@ -271,6 +281,7 @@ extension SQLQueryFetcher {
 
 // MARK: - Run (EventLoopFuture)
 
+#if canImport(NIOCore)
 extension SQLQueryFetcher {
     /// Using a default-configured ``SQLRowDecoder``, call the provided handler closure with the result of decoding
     /// each output row, if any, as a given type.
@@ -336,6 +347,8 @@ extension SQLQueryFetcher {
         self.database.execute(sql: self.query, handler)
     }
 }
+
+#endif  // canImport(NIOCore)
 
 // MARK: - Run (async)
 

--- a/Sources/SQLKit/Database/SQLDatabase.swift
+++ b/Sources/SQLKit/Database/SQLDatabase.swift
@@ -1,5 +1,9 @@
+// SwiftNIO is not linked on every platform SQLKit supports (see Package.swift); the
+// EventLoopFuture surface below is elided where it is absent.
+#if canImport(NIOCore)
 import protocol NIOCore.EventLoop
 import class NIOCore.EventLoopFuture
+#endif
 import struct Logging.Logger
 
 /// The common interface to SQLKit for both drivers and client code.
@@ -56,6 +60,9 @@ public protocol SQLDatabase: Sendable {
     /// The `Logger` used for logging all operations relating to a given database.
     var logger: Logger { get }
     
+    // N.B.: Each `#if` encloses the doc comment of the declaration it gates; placed between the
+    // two it would silently detach the doc from the symbol graph.
+    #if canImport(NIOCore)
     /// The `EventLoop` used for asynchronous operations on a given database.
     ///
     /// If there is no specific `EventLoop` which handles the database (such as because it is a connection pool which
@@ -63,7 +70,8 @@ public protocol SQLDatabase: Sendable {
     /// Concurrency or some other asynchronous execution technology), a single consistent `EventLoop` must be chosen
     /// for the database and returned for this property nonetheless.
     var eventLoop: any EventLoop { get }
-    
+    #endif  // canImport(NIOCore)
+
     /// The version number the database reports for itself.
     ///
     /// The version must be provided via a type conforming to the ``SQLDatabaseReportedVersion`` protocol. If the
@@ -102,6 +110,7 @@ public protocol SQLDatabase: Sendable {
     /// > it's unavoidable, as there are no direct entry points to SQLKit without a driver.
     var queryLogLevel: Logger.Level? { get }
 
+    #if canImport(NIOCore)
     /// Requests that the given generic SQL query be serialized and executed on the database, and that
     /// the `onRow` closure be invoked once for each result row the query returns (if any).
     ///
@@ -118,6 +127,7 @@ public protocol SQLDatabase: Sendable {
         sql query: any SQLExpression,
         _ onRow: @escaping @Sendable (any SQLRow) -> ()
     ) -> EventLoopFuture<Void>
+    #endif  // canImport(NIOCore)
 
     /// Requests that the given generic SQL query be serialized and executed on the database, and that
     /// the `onRow` closure be invoked once for each result row the query returns (if any).
@@ -200,6 +210,10 @@ extension SQLDatabase {
 }
 
 extension SQLDatabase {
+    // This default bridges the `async` requirement to the legacy `EventLoopFuture` one, so it can
+    // only exist where the latter does. Without SwiftNIO there is no future overload to forward to
+    // and conformers implement the `async` `execute` directly.
+    #if canImport(NIOCore)
     /// The default implementation for ``execute(sql:_:)-4eg19``.
     @inlinable
     public func execute(
@@ -208,7 +222,8 @@ extension SQLDatabase {
     ) async throws {
         try await self.execute(sql: query, onRow).get()
     }
-    
+    #endif  // canImport(NIOCore)
+
     /// The default implementation for ``withSession(_:)-9b68j``.
     @inlinable
     public func withSession<R>(
@@ -227,10 +242,12 @@ private struct CustomLoggerSQLDatabase<D: SQLDatabase>: SQLDatabase {
     // See `SQLDatabase.logger`.
     let logger: Logger
     
+    #if canImport(NIOCore)
     // See `SQLDatabase.eventLoop`.
     var eventLoop: any EventLoop {
         self.database.eventLoop
     }
+    #endif
 
     // See `SQLDatabase.version`.
     var version: (any SQLDatabaseReportedVersion)? {
@@ -247,6 +264,7 @@ private struct CustomLoggerSQLDatabase<D: SQLDatabase>: SQLDatabase {
         self.database.queryLogLevel
     }
     
+    #if canImport(NIOCore)
     // See `SQLDatabase.execute(sql:_:)`.
     func execute(
         sql query: any SQLExpression,
@@ -254,6 +272,7 @@ private struct CustomLoggerSQLDatabase<D: SQLDatabase>: SQLDatabase {
     ) -> EventLoopFuture<Void> {
         self.database.execute(sql: query, onRow)
     }
+    #endif  // canImport(NIOCore)
 
     // See `SQLDatabase.execute(sql:_:)`.
     func execute(

--- a/Sources/SQLKit/Exports.swift
+++ b/Sources/SQLKit/Exports.swift
@@ -1,3 +1,5 @@
+#if canImport(NIOCore)
 @_documentation(visibility: internal) @_exported import protocol NIOCore.EventLoop
 @_documentation(visibility: internal) @_exported import class NIOCore.EventLoopFuture
+#endif
 @_documentation(visibility: internal) @_exported import struct Logging.Logger

--- a/Sources/SQLKitBenchmark/SQLBenchmarker.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmarker.swift
@@ -1,5 +1,7 @@
 import Logging
+#if canImport(NIOCore)
 import NIOCore
+#endif
 public import SQLKit
 import XCTest
 
@@ -21,6 +23,8 @@ public final class SQLBenchmarker: Sendable {
         }
     }
     
+    // The deprecated EventLoopFuture bridges are elided where SwiftNIO is unavailable.
+    #if canImport(NIOCore)
     @available(*, deprecated, renamed: "runAllTests()", message: "Use `runAllTests()` instead.")
     public func testAll() throws {
         try database.eventLoop.makeFutureWithTask { try await self.runAllTests() }.wait()
@@ -30,6 +34,7 @@ public final class SQLBenchmarker: Sendable {
     public func run() throws {
         try self.testAll()
     }
+    #endif  // canImport(NIOCore)
     
     func runTest(
         _ name: String = #function,

--- a/Tests/SQLKitTests/AsyncTests.swift
+++ b/Tests/SQLKitTests/AsyncTests.swift
@@ -1,4 +1,6 @@
+#if canImport(NIOCore)
 import NIOCore
+#endif
 import OrderedCollections
 import SQLKit
 import Testing

--- a/Tests/SQLKitTests/BaseTests.swift
+++ b/Tests/SQLKitTests/BaseTests.swift
@@ -1,7 +1,9 @@
 @testable import SQLKit
 import struct Logging.Logger
+#if canImport(NIOCore)
 import protocol NIOCore.EventLoop
 import class NIOCore.EventLoopFuture
+#endif
 import SQLKitBenchmark
 import Testing
 

--- a/Tests/SQLKitTests/TestMocks.swift
+++ b/Tests/SQLKitTests/TestMocks.swift
@@ -1,8 +1,10 @@
 import OrderedCollections
 public import SQLKit
+#if canImport(NIOCore)
 import protocol NIOCore.EventLoop
 import class NIOCore.EventLoopFuture
 import class NIOEmbedded.NIOAsyncTestingEventLoop
+#endif
 import Logging
 #if canImport(Dispatch)
 import class Dispatch.DispatchQueue


### PR DESCRIPTION
Builds SQLKit on `wasm32-unknown-wasip1` without SwiftNIO. Since vapor/sql-kit#190 and swift-nio's WASI support, SQLKit itself already builds there with NIOCore linked; SwiftNIO is elided anyway because the drivers beneath SQLKit cannot build it at all (NIOPosix needs the POSIX sockets and threads WASI preview 1 lacks), so nothing on that platform can implement an `EventLoopFuture` surface, and keeping `canImport(NIOCore)` uniformly false across the stack means one condition selects the async-only configuration everywhere. Compiling under Embedded Swift needs a further set of gates, including a change to how the bound-parameter constraint is spelled; that work is kept out of this PR and is not being proposed yet, which keeps this diff small.

**Changes:**

- The legacy `EventLoopFuture` surface goes behind `#if canImport(NIOCore)`: `SQLDatabase.eventLoop`, the future-returning `execute(sql:_:)` requirement and its default bridge, `SQLQueryBuilder.run()`, the three `SQLQueryFetcher` future families, the NIOCore re-exports, and `SQLBenchmarker`'s two deprecated bridges. The `async` surface, already the recommended API at every one of those call sites, is untouched and is all that remains where SwiftNIO is absent.
- Each `#if` encloses the doc comment of the declaration it gates rather than sitting between the two. A `#if` in that position detaches the comment: the declaration still compiles, but the symbol graph reports it as undocumented and the published docs lose the entry, with no build-time diagnostic.
- The manifest gates `NIOCore` (and the test target's `NIOCore`/`NIOEmbedded`) with `.when(platforms: nonWASIPlatforms)`, the same spelled-out-list idiom as apple/swift-nio#2671 and swift-crypto, with a comment pinning the list to the manifest's tools version. The test suite's imports of those modules gate on the same condition, because `swift build` evaluates `--explicit-target-dependency-import-check` for every target in the graph, including the test target it does not build.

**Where SwiftNIO is present, nothing changes:** every gate is unconditionally true, and `swift package diagnose-api-breaking-changes` reports no breaking changes in SQLKit or SQLKitBenchmark. `swift build -Xswiftc -emit-symbol-graph` emits the same symbols with the same `docComment` line counts as before.

**What WASI loses:** the `EventLoopFuture` half of the API. `SQLDatabase.eventLoop`, the future-returning `execute(sql:_:)` and `SQLQueryBuilder.run()`, the future variants of the `SQLQueryFetcher` `first`/`all`/`run` families, the NIOCore re-exports, and `SQLBenchmarker`'s deprecated bridges. The `async` surface, already the recommended API, is what remains. One driver-facing nuance: the default implementation of the `async` `execute(sql:_:)` forwards to the future-returning requirement, so where SwiftNIO is absent there is no future overload to forward to and drivers implement the `async` requirement directly, which is the primitive they should be implementing anyway.

**Verification:**

- Native `swift build` and `swift test`: green, 169 tests, including with CI's `--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable`.
- WASI (`--swift-sdk swift-6.3.1-RELEASE_wasm`): green with the same flags, zero SwiftNIO object files, no NIO symbols in the built objects. `SQLKitBenchmark` still builds for regular WASI.
- No CI change needed: sql-kit already passes `with_wasm: true` to `vapor/ci`.

**On tests:** no test cases are added. The change introduces no behavior on any platform that compiled before (every gate is unconditionally true where SwiftNIO is present, and the symbol graph is byte-identical), and the configuration it does add is exercised by the wasm CI lane.

**Notes for review:** every gate is a capability gate (`canImport`), in `Sources/` only, never in a manifest; there is no `os(WASI)` anywhere. All three packages in this stack gate the same modules on the same condition, and a package that did build NIOCore for WASI would fail loudly at compile. No SwiftPM traits, no versioned manifest, no tools-version bump, no new dependencies.
